### PR TITLE
Improve historic hook callbacks

### DIFF
--- a/pluggy.py
+++ b/pluggy.py
@@ -747,7 +747,9 @@ class _HookCaller(object):
     def call_historic(self, proc=None, kwargs=None):
         self._call_history.append((kwargs or {}, proc))
         # historizing hooks don't return results
-        self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
+        res = self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
+        if res and proc is not None:
+            proc(res[0])
 
     def call_extra(self, methods, kwargs):
         """ Call the hook with some additional temporarily participating

--- a/testing/test_pluggy.py
+++ b/testing/test_pluggy.py
@@ -212,6 +212,25 @@ class TestPluginManager:
         pm.register(Plugin())
         assert l == [10]
 
+    def test_with_immediate_result_memorized(self, pm):
+        class Hooks:
+            @hookspec(historic=True)
+            def he_method1(self, arg):
+                pass
+        pm.add_hookspecs(Hooks)
+
+        class Plugin:
+            @hookimpl
+            def he_method1(self, arg):
+                return arg * 10
+
+        l = []
+        pm.register(Plugin())
+
+        he_method1 = pm.hook.he_method1
+        he_method1.call_historic(lambda res: l.append(res), dict(arg=1))
+        assert l == [10]
+
     def test_register_historic_incompat_hookwrapper(self, pm):
         class Hooks:
             @hookspec(historic=True)


### PR DESCRIPTION
Historic callbacks always immediately invoke all registered hooks, but the callback is **only** triggered on hooks that come from newly registered plugins. This change captures all information.

The added test fails on the current pluggy, so should catch any regressions should this be accepted.

I found this toying with pytest. The only historic hook in pytest is `pytest_namespace`, and the only reason this issue isn't a problem in pytest is the order in which things are setup. However if someone wanted to implement something similar inside a 3rd party plugin, this inconsistency means some results may be lost even though all hooks get triggered.
