### PR TITLE
Added required argument to HookspecMarker

### DIFF
--- a/pluggy.py
+++ b/pluggy.py
@@ -99,6 +99,7 @@ class HookspecMarker:
         If historic is True calls to a hook will be memorized and replayed
         on later registered plugins.
 
+        If required is True calls to a hook will fail if there is not at least one implementation for it.
         """
         def setattr_hookspec_opts(func):
             if historic and firstresult:

--- a/pluggy.py
+++ b/pluggy.py
@@ -86,7 +86,7 @@ class HookspecMarker:
     def __init__(self, project_name):
         self.project_name = project_name
 
-    def __call__(self, function=None, firstresult=False, historic=False):
+    def __call__(self, function=None, firstresult=False, historic=False, required=False):
         """ if passed a function, directly sets attributes on the function
         which will make it discoverable to add_hookspecs().  If passed no
         function, returns a decorator which can be applied to a function
@@ -104,7 +104,7 @@ class HookspecMarker:
             if historic and firstresult:
                 raise ValueError("cannot have a historic firstresult hook")
             setattr(func, self.project_name + "_spec",
-                   dict(firstresult=firstresult, historic=historic))
+                    dict(firstresult=firstresult, historic=historic, required=required))
             return func
 
         if function is not None:
@@ -596,6 +596,9 @@ class _MultiCall:
         self.specopts = specopts
 
     def execute(self):
+        if self.specopts.get("required", False) and not self.hook_impls:
+            raise HookCallError("hook needs at least one implementation")
+
         all_kwargs = self.kwargs
         self.results = results = []
         firstresult = self.specopts.get("firstresult")

--- a/testing/test_pluggy.py
+++ b/testing/test_pluggy.py
@@ -313,6 +313,47 @@ class TestPluginManager:
         with pytest.raises(ValueError):
             pm.add_hookspecs(10)
 
+    def test_requireimpl_with_missing_impl(self, pm):
+        class Hooks:
+            @hookspec(required=True)
+            def he_method1(self):
+                pass
+
+        pm.add_hookspecs(Hooks)
+
+        with pytest.raises(HookCallError) as hook_call_err:
+            pm.hook.he_method1()
+
+        assert "needs" in str(hook_call_err.value)
+        assert "implementation" in str(hook_call_err.value)
+
+    def test_requireimpl_with_impl(self, pm):
+        class Hooks:
+            @hookspec(required=True)
+            def he_method1(self):
+                pass
+
+        pm.add_hookspecs(Hooks)
+
+        class Plugin:
+            @hookimpl
+            def he_method1(self):
+                return 1
+
+        pm.register(Plugin())
+
+        assert pm.hook.he_method1() == [1]
+
+    def test_requireimpl_without_specopts(self, pm):
+        class Hooks:
+            @hookspec
+            def he_method1(self):
+                pass
+
+        del getattr(Hooks.he_method1, hookspec.project_name + "_spec")['required']
+        pm.add_hookspecs(Hooks)
+        assert pm.hook.he_method1() == []
+
 
 class TestAddMethodOrdering:
     @pytest.fixture


### PR DESCRIPTION
If this is set to True calls to the hook will raise HookCallError if there is not at least one registered implementation.
It uses `self.specopts.get` with a default value so it stays compatible to manual setting of the specopts dict.

see Issue #20 
