### PR TITLE
Add license_file to setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [bdist_wheel]
 universal=1
 
+[metadata]
+license_file=LICENSE
+
 [devpi:upload]
 formats=sdist.tgz,bdist_wheel


### PR DESCRIPTION
This ensures that the LICENSE file is included in a built wheel.
Otherwise a wheel would be missing this entirely.