### PR TITLE
Baseline benchmarking tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,36 @@
 sudo: false
 language: python
 python:
-
     - '2.6'
     - '2.7'
     - '3.3'
     - '3.4'
     - '3.5'
-    - '3.6-dev'
+    - '3.6'
     - pypy
     - nightly
+
 # command to install dependencies
 install: "pip install -U tox"
-# # command to run tests
+
+# command to run tests
 env:
   matrix:
     - TOXENV=py-pytest28
     - TOXENV=py-pytest29
     - TOXENV=py-pytest30
+
 matrix:
   include:
     - python: '2.7'
       env: TOXENV=check
-    - python: '3.5'
+    - python: '3.6'
       env: TOXENV=check
+    - python: '2.7'
+      env: TOXENV=benchmark
+    - python: '3.6'
+      env: TOXENV=benchmark
+
 script:
  - tox --recreate -e $TOXENV
 

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -1,0 +1,58 @@
+"""
+Benchmarking and performance tests.
+"""
+import pytest
+
+from pluggy import _MultiCall, HookImpl
+from pluggy import HookspecMarker, HookimplMarker
+
+
+hookspec = HookspecMarker("example")
+hookimpl = HookimplMarker("example")
+
+
+def MC(methods, kwargs, firstresult=False):
+    hookfuncs = []
+    for method in methods:
+        f = HookImpl(None, "<temp>", method, method.example_impl)
+        hookfuncs.append(f)
+    return _MultiCall(hookfuncs, kwargs, {"firstresult": firstresult})
+
+
+@hookimpl(hookwrapper=True)
+def m1(arg1, arg2, arg3):
+    yield
+
+
+@hookimpl
+def m2(arg1, arg2, arg3):
+    return arg1, arg2, arg3
+
+
+@hookimpl(hookwrapper=True)
+def w1(arg1, arg2, arg3):
+    yield
+
+
+@hookimpl(hookwrapper=True)
+def w2(arg1, arg2, arg3):
+    yield
+
+
+def inner_exec(methods):
+    return MC(methods, {'arg1': 1, 'arg2': 2, 'arg3': 3}).execute()
+
+
+@pytest.mark.benchmark
+def test_hookimpls_speed(benchmark):
+    benchmark(inner_exec, [m1, m2])
+
+
+@pytest.mark.benchmark
+def test_hookwrappers_speed(benchmark):
+    benchmark(inner_exec, [w1, w2])
+
+
+@pytest.mark.benchmark
+def test_impls_and_wrappers_speed(benchmark):
+    benchmark(inner_exec, [m1, m2, w1, w2])

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,16 @@
 envlist=check,py{26,27,34,35,36,py}-pytest{28,29,30}
 
 [testenv]
-commands= py.test {posargs:testing/}
+commands=py.test {posargs:testing/}
 deps=
   pytest28: pytest~=2.8.0
   pytest29: pytest~=2.9.0
   pytest30: pytest~=3.0.0
+
+[testenv:benchmark]
+commands=py.test {posargs:testing/benchmark.py}
+deps=
+  pytest
   pytest-benchmark
 
 [testenv:check]
@@ -17,21 +22,20 @@ commands =
   flake8 pluggy.py setup.py testing
   rst-lint CHANGELOG.rst README.rst
 
-
 [testenv:docs]
 deps =
     sphinx
     pygments
-
 commands =
     sphinx-build \
         -b html \
         {toxinidir}/docs {toxinidir}/build/html-docs
+
 [pytest]
 minversion=2.0
 #--pyargs --doctest-modules --ignore=.tox
-addopts= -rxsX
-norecursedirs = .tox ja .hg .env*
+addopts=-rxsX
+norecursedirs=.tox ja .hg .env*
 
 [flake8]
-max-line-length = 99
+max-line-length=99

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=check,py{26,27,34,35,py}-pytest{28,29,30}
+envlist=check,py{26,27,34,35,36,py}-pytest{28,29,30}
 
 [testenv]
 commands= py.test {posargs:testing/}
@@ -7,13 +7,13 @@ deps=
   pytest28: pytest~=2.8.0
   pytest29: pytest~=2.9.0
   pytest30: pytest~=3.0.0
-
+  pytest-benchmark
 
 [testenv:check]
 deps =
   flake8
-  restructuredtext_lint 
-commands = 
+  restructuredtext_lint
+commands =
   flake8 pluggy.py setup.py testing
   rst-lint CHANGELOG.rst README.rst
 
@@ -30,7 +30,7 @@ commands =
 [pytest]
 minversion=2.0
 #--pyargs --doctest-modules --ignore=.tox
-addopts= -rxsX 
+addopts= -rxsX
 norecursedirs = .tox ja .hg .env*
 
 [flake8]


### PR DESCRIPTION
This adds some basic speed tests for the `_MultiCall` loop.
The goal is to extend this out so what we avoid performance degradation in addressing #23 and #15.
The next set of tests will include full code path(s) initiated by `_HookCaller` methods.
I was also thinking of adding collection speed tests.

Treat this PR as a first draft to get some opinions going.
So far the results are about what I'd expect - `pypy` killing it, `py27` and `py36` the runners up.