### PR TITLE
Encapsulate spec definitions with a class

### DIFF
--- a/changelog/57.trivial.rst
+++ b/changelog/57.trivial.rst
@@ -1,0 +1,1 @@
+Encapsulate hook specifications in a type for easier introspection.

--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -56,7 +56,9 @@ class PluginManager(object):
             )
         self._implprefix = implprefix
         self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
-            methods, kwargs, firstresult=hook.spec_opts.get("firstresult")
+            methods,
+            kwargs,
+            firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
         )
 
     def _hookexec(self, hook, methods, kwargs):
@@ -215,10 +217,10 @@ class PluginManager(object):
                 "Plugin %r\nhook %r\nhistoric incompatible to hookwrapper"
                 % (hookimpl.plugin_name, hook.name),
             )
-        if hook.warn_on_impl:
-            _warn_for_function(hook.warn_on_impl, hookimpl.function)
+        if hook.spec.warn_on_impl:
+            _warn_for_function(hook.spec.warn_on_impl, hookimpl.function)
         # positional arg checking
-        notinspec = set(hookimpl.argnames) - set(hook.argnames)
+        notinspec = set(hookimpl.argnames) - set(hook.spec.argnames)
         if notinspec:
             raise PluginValidationError(
                 hookimpl.plugin,
@@ -325,7 +327,7 @@ class PluginManager(object):
         plugins_to_remove = [plug for plug in remove_plugins if hasattr(plug, name)]
         if plugins_to_remove:
             hc = _HookCaller(
-                orig.name, orig._hookexec, orig._specmodule_or_class, orig.spec_opts
+                orig.name, orig._hookexec, orig.spec.namespace, orig.spec.opts
             )
             for hookimpl in orig._wrappers + orig._nonwrappers:
                 plugin = hookimpl.plugin

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -15,7 +15,7 @@ def MC(methods, kwargs, callertype, firstresult=False):
     for method in methods:
         f = HookImpl(None, "<temp>", method, method.example_impl)
         hookfuncs.append(f)
-    return callertype(hookfuncs, kwargs, {"firstresult": firstresult})
+    return callertype(hookfuncs, kwargs, firstresult=firstresult)
 
 
 @hookimpl

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -169,9 +169,9 @@ def test_hookspec(pm):
             pass
 
     pm.add_hookspecs(HookSpec)
-    assert not pm.hook.he_myhook1.spec_opts["firstresult"]
-    assert pm.hook.he_myhook2.spec_opts["firstresult"]
-    assert not pm.hook.he_myhook3.spec_opts["firstresult"]
+    assert not pm.hook.he_myhook1.spec.opts["firstresult"]
+    assert pm.hook.he_myhook2.spec.opts["firstresult"]
+    assert not pm.hook.he_myhook3.spec.opts["firstresult"]
 
 
 @pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])


### PR DESCRIPTION
Allows for easier introspection of spec definitions including function
signatures and hook options. Originally introduced to address ~#47~ #15 and #43 which
requires keeping track of spec default arguments values.