### PR TITLE
Remove duplicate 'firstresult' test

### DIFF
--- a/testing/test_hookrelay.py
+++ b/testing/test_hookrelay.py
@@ -68,11 +68,23 @@ def test_firstresult_definition(pm):
 
     pm.add_hookspecs(Api)
 
-    class Plugin(object):
+    class Plugin1(object):
         @hookimpl
         def hello(self, arg):
             return arg + 1
 
-    pm.register(Plugin())
+    class Plugin2(object):
+        @hookimpl
+        def hello(self, arg):
+            return arg - 1
+
+    class Plugin3(object):
+        @hookimpl
+        def hello(self, arg):
+            return None
+
+    pm.register(Plugin1())  # discarded - not the last registered plugin
+    pm.register(Plugin2())  # used as result
+    pm.register(Plugin3())  # None result is ignored
     res = pm.hook.hello(arg=3)
-    assert res == 4
+    assert res == 2

--- a/testing/test_method_ordering.py
+++ b/testing/test_method_ordering.py
@@ -180,24 +180,6 @@ def test_hookimpl(name, val):
         assert not hasattr(he_myhook1, name)
 
 
-def test_decorator_functional(pm):
-    class HookSpec(object):
-        @hookspec(firstresult=True)
-        def he_myhook(self, arg1):
-            """ add to arg1 """
-
-    pm.add_hookspecs(HookSpec)
-
-    class Plugin(object):
-        @hookimpl()
-        def he_myhook(self, arg1):
-            return arg1 + 1
-
-    pm.register(Plugin())
-    results = pm.hook.he_myhook(arg1=17)
-    assert results == 18
-
-
 def test_load_setuptools_instantiation(monkeypatch, pm):
     pkg_resources = pytest.importorskip("pkg_resources")
 


### PR DESCRIPTION
Remove `test_method_ordering.test_decorator_functional` as it is
duplicate of an already incomplete test. 

Fix up `test_firstresult_definition` to be more more complete and actually test
that when multiple hooks are registered for a spec marked with `firstresult`
the first result is only ever returned.

Fixes #61 
