### PR TITLE
Update version to 0.5.2.dev

### DIFF
--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -2,7 +2,7 @@ import inspect
 import warnings
 from .callers import _MultiCall, HookCallError, _raise_wrapfail, _Result
 
-__version__ = '0.5.1'
+__version__ = '0.5.2.dev'
 
 __all__ = ["PluginManager", "PluginValidationError", "HookCallError",
            "HookspecMarker", "HookimplMarker"]


### PR DESCRIPTION
This helps to differentiate from an official release and dev version.

Until #73 is done we have to remember to do that manually after the release as well.