### PR TITLE
Test with pytest from master/features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,44 @@
 sudo: false
 language: python
-python:
-    - '2.6'
-    - '2.7'
-    - '3.3'
-    - '3.4'
-    - '3.5'
-    - '3.6'
-    - pypy
-    - nightly
-
-# command to install dependencies
-install: "pip install -U tox"
-
-# command to run tests
-env:
-  matrix:
-    - TOXENV=py-pytest28
-    - TOXENV=py-pytest29
-    - TOXENV=py-pytest30
 
 matrix:
   include:
-    - python: '2.7'
-      env: TOXENV=check
     - python: '3.6'
       env: TOXENV=check
+    - python: '3.6'
+      env: TOXENV=docs
+    - python: '2.6'
+      env: TOXENV=py26-pytestrelease
     - python: '2.7'
-      env: TOXENV=benchmark
+      env: TOXENV=py27-pytestrelease
+    - python: '3.3'
+      env: TOXENV=py33-pytestrelease
+    - python: '3.4'
+      env: TOXENV=py34-pytestrelease
+    - python: '3.5'
+      env: TOXENV=py35-pytestrelease
+    - python: '3.6'
+      env: TOXENV=py36-pytestrelease
+    - python: 'pypy'
+      env: TOXENV=pypy-pytestrelease
+    - python: 'nightly'
+      env: TOXENV=py37-pytestrelease
+    - python: '2.7'
+      env: TOXENV=py27-pytestmaster
+    - python: '2.7'
+      env: TOXENV=py27-pytestfeatures
+    - python: '3.6'
+      env: TOXENV=py36-pytestmaster
+    - python: '3.6'
+      env: TOXENV=py36-pytestfeatures
     - python: '3.6'
       env: TOXENV=benchmark
 
+install:
+  - pip install -U tox
+
 script:
- - tox --recreate -e $TOXENV
+  - tox
 
 notifications:
   irc:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,18 @@
+environment:
+  matrix:
+  # note: please use "tox --listenvs" to populate the build matrix below
+  - TOXENV: "check"
+  - TOXENV: "docs"
+  - TOXENV: "py26-pytestrelease"
+  - TOXENV: "py27-pytestrelease"
+  - TOXENV: "py34-pytestrelease"
+  - TOXENV: "py35-pytestrelease"
+  - TOXENV: "py36-pytestrelease"
+  - TOXENV: "pypy-pytestrelease"
+  - TOXENV: "py27-pytestmaster"
+  - TOXENV: "py27-pytestfeatures"
+  - TOXENV: "py36-pytestmaster"
+  - TOXENV: "py36-pytestfeatures"
 
 install:
   - echo Installed Pythons
@@ -18,4 +33,3 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   - C:\Python35\python -m tox
-  

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist=check,py{26,27,34,35,36,py}-pytest{28,29,30}
+envlist=check,docs,py{26,27,34,35,36,py}-pytestrelease,py{27,36}-pytest{master,features}
 
 [testenv]
 commands=py.test {posargs:testing/}
 deps=
-  pytest28: pytest~=2.8.0
-  pytest29: pytest~=2.9.0
-  pytest30: pytest~=3.0.0
+  pytestrelease: pytest
+  pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
+  pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features
 
 [testenv:benchmark]
 commands=py.test {posargs:testing/benchmark.py}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist=check,docs,py{26,27,34,35,36,py}-pytestrelease,py{27,36}-pytest{master,f
 
 [testenv]
 commands=py.test {posargs:testing/}
+setenv=
+  _PYTEST_SETUP_SKIP_PLUGGY_DEP=1
 deps=
   pytestrelease: pytest
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master


### PR DESCRIPTION
Fix #76 

The environment for `pytest-features` is failing because pytest currently pins pluggy to `>=4.0,<5`, so `tox` cannot create the environment.

I propose we change `pytest`'s `setup.py` to optionally take the pluggy specification from an environment variable `_PYTEST_SETUP_PLUGGY_SPEC` if defined instead of what's encoded in `setup.py`,  roughly:

```python
def main():
    install_requires = ['py>=1.4.33', 'six>=1.10.0','setuptools', 'pluggy>=0.4.0,<0.5']
```

Into:

```python
def main():
    pluggy_spec = os.environ.get('_PYTEST_SETUP_PLUGGY_SPEC', 'pluggy>=0.4.0,<0.5')
    install_requires = ['py>=1.4.33', 'six>=1.10.0','setuptools', pluggy_spec]
```

We will probably need to do something like that anyway for pytest-dev/pytest#2737.