### PR TITLE
Re-add _Result.result as an attr which triggers a deprecation warning

### DIFF
--- a/pluggy/callers.py
+++ b/pluggy/callers.py
@@ -2,7 +2,7 @@
 Call loop machinery
 '''
 import sys
-
+import warnings
 
 _py3 = sys.version_info > (3, 0)
 
@@ -32,6 +32,13 @@ class _Result(object):
     @property
     def excinfo(self):
         return self._excinfo
+
+    @property
+    def result(self):
+        """Get the result(s) for this hook call (DEPRECATED in favor of ``get_result()``)."""
+        msg = 'Use get_result() which forces correct exception handling'
+        warnings.warn(DeprecationWarning(msg))
+        return self._result
 
     @classmethod
     def from_call(cls, func):

--- a/pluggy/callers.py
+++ b/pluggy/callers.py
@@ -37,7 +37,7 @@ class _Result(object):
     def result(self):
         """Get the result(s) for this hook call (DEPRECATED in favor of ``get_result()``)."""
         msg = 'Use get_result() which forces correct exception handling'
-        warnings.warn(DeprecationWarning(msg))
+        warnings.warn(DeprecationWarning(msg), stacklevel=2)
         return self._result
 
     @classmethod

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -1,6 +1,8 @@
 import warnings
-from pluggy import PluginManager, HookimplMarker, HookspecMarker
 
+import pytest
+
+from pluggy import PluginManager, HookimplMarker, HookspecMarker, _Result
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
@@ -93,3 +95,9 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
         warning = warns[-1]
         assert issubclass(warning.category, Warning)
         assert "Argument(s) ('arg2',)" in str(warning.message)
+
+
+def test_result_deprecated():
+    r = _Result(10, None)
+    with pytest.deprecated_call():
+        assert r.result == 10


### PR DESCRIPTION
This should fix the `pluggymaster` environment in pytest.

Guys I was wondering if it wouldn't be better instead of `get_result()` to have `result` as a read-only property, with the same semantics as `get_result()`? 

`outcome.result` is more user-friendly than `outcome.get_result()`. It seems we are not using one of the key benefits of properties of being able to change an attribute access into a property at some later time without breaking users.