### PR TITLE
Turned warnings into errors

### DIFF
--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -675,7 +675,8 @@ class _HookCaller(object):
                 warnings.warn(
                     "Argument(s) {0} which are declared in the hookspec "
                     "can not be found in this hook call"
-                    .format(tuple(notincall))
+                    .format(tuple(notincall)),
+                    stacklevel=2,
                 )
         return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
 

--- a/testing/test_method_ordering.py
+++ b/testing/test_method_ordering.py
@@ -238,7 +238,7 @@ def test_add_tracefuncs(he_pm):
 
     undo = he_pm.add_hookcall_monitoring(before, after)
 
-    he_pm.hook.he_method1()
+    he_pm.hook.he_method1(arg=1)
     assert len(l) == 4
     assert l[0][0] == "he_method1"
     assert len(l[0][1]) == 2
@@ -249,7 +249,7 @@ def test_add_tracefuncs(he_pm):
     assert l[3][1] == l[0][0]
 
     undo()
-    he_pm.hook.he_method1()
+    he_pm.hook.he_method1(arg=1)
     assert len(l) == 4 + 2
 
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -284,7 +284,8 @@ def test_call_with_too_few_args(pm):
             0 / 0
     pm.register(Plugin1())
     with pytest.raises(HookCallError):
-        pm.hook.he_method1()
+        with pytest.warns(UserWarning):
+            pm.hook.he_method1()
 
 
 def test_subset_hook_caller(pm):

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,10 @@ minversion=2.0
 #--pyargs --doctest-modules --ignore=.tox
 addopts=-rxsX
 norecursedirs=.tox ja .hg .env*
+filterwarnings =
+  error
+  # inspect.getargspec() ignored, should be fixed in #81
+  ignore:inspect.getargspec().*deprecated
 
 [flake8]
 max-line-length=99


### PR DESCRIPTION
- Fix two correct warnings
- Used pytest.warns() around a valid warning being issued

Should remove the warning exception for #81 when we tackle that.

Fix #78