### PR TITLE
Multicall to func

### DIFF
--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 import warnings
-from .callers import _MultiCall, HookCallError, _Result, _LegacyMultiCall
+from .callers import _multicall, HookCallError, _Result, _legacymulticall
 
 __version__ = '0.5.3.dev'
 
@@ -213,7 +213,7 @@ class PluginManager(object):
         self._inner_hookexec = lambda hook, methods, kwargs: \
             hook.multicall(
                 methods, kwargs, specopts=hook.spec_opts, hook=hook
-            ).execute()
+            )
 
     def _hookexec(self, hook, methods, kwargs):
         # called from all hookcaller instances.
@@ -535,7 +535,7 @@ class _HookCaller(object):
         self._hookexec = hook_execute
         self.argnames = None
         self.kwargnames = None
-        self.multicall = _MultiCall
+        self.multicall = _multicall
         if specmodule_or_class is not None:
             assert spec_opts is not None
             self.set_specification(specmodule_or_class, spec_opts)
@@ -592,7 +592,7 @@ class _HookCaller(object):
                 "removed in an upcoming release.",
                 DeprecationWarning
             )
-            self.multicall = _LegacyMultiCall
+            self.multicall = _legacymulticall
 
     def __repr__(self):
         return "<_HookCaller %r>" % (self.name,)

--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 import warnings
-from .callers import _MultiCall, HookCallError, _raise_wrapfail, _Result
+from .callers import _MultiCall, HookCallError, _Result, _LegacyMultiCall
 
 __version__ = '0.5.3.dev'
 
@@ -164,25 +164,6 @@ class _TagTracerSub(object):
 
     def get(self, name):
         return self.__class__(self.root, self.tags + (name,))
-
-
-def _wrapped_call(wrap_controller, func):
-    """ Wrap calling to a function with a generator which needs to yield
-    exactly once.  The yield point will trigger calling the wrapped function
-    and return its ``_Result`` to the yield point.  The generator then needs
-    to finish (raise StopIteration) in order for the wrapped call to complete.
-    """
-    try:
-        next(wrap_controller)   # first yield
-    except StopIteration:
-        _raise_wrapfail(wrap_controller, "did not yield")
-    call_outcome = _Result.from_call(func)
-    try:
-        wrap_controller.send(call_outcome)
-        _raise_wrapfail(wrap_controller, "has second yield")
-    except StopIteration:
-        pass
-    return call_outcome.get_result()
 
 
 class _TracedHookExecution(object):
@@ -483,54 +464,6 @@ class PluginManager(object):
                     self._plugin2hookcallers.setdefault(plugin, []).append(hc)
             return hc
         return orig
-
-
-class _LegacyMultiCall(object):
-    """ execute a call into multiple python functions/methods. """
-
-    # XXX note that the __multicall__ argument is supported only
-    # for pytest compatibility reasons.  It was never officially
-    # supported there and is explicitely deprecated since 2.8
-    # so we can remove it soon, allowing to avoid the below recursion
-    # in execute() and simplify/speed up the execute loop.
-
-    def __init__(self, hook_impls, kwargs, specopts={}, hook=None):
-        self.hook = hook
-        self.hook_impls = hook_impls
-        self.caller_kwargs = kwargs  # come from _HookCaller.__call__()
-        self.caller_kwargs["__multicall__"] = self
-        self.specopts = hook.spec_opts if hook else specopts
-
-    def execute(self):
-        caller_kwargs = self.caller_kwargs
-        self.results = results = []
-        firstresult = self.specopts.get("firstresult")
-
-        while self.hook_impls:
-            hook_impl = self.hook_impls.pop()
-            try:
-                args = [caller_kwargs[argname] for argname in hook_impl.argnames]
-            except KeyError:
-                for argname in hook_impl.argnames:
-                    if argname not in caller_kwargs:
-                        raise HookCallError(
-                            "hook call must provide argument %r" % (argname,))
-            if hook_impl.hookwrapper:
-                return _wrapped_call(hook_impl.function(*args), self.execute)
-            res = hook_impl.function(*args)
-            if res is not None:
-                if firstresult:
-                    return res
-                results.append(res)
-
-        if not firstresult:
-            return results
-
-    def __repr__(self):
-        status = "%d meths" % (len(self.hook_impls),)
-        if hasattr(self, "results"):
-            status = ("%d results, " % len(self.results)) + status
-        return "<_MultiCall %s, kwargs=%r>" % (status, self.caller_kwargs)
 
 
 def varnames(func):

--- a/pluggy/callers.py
+++ b/pluggy/callers.py
@@ -77,6 +77,73 @@ class _Result(object):
             _reraise(*ex)  # noqa
 
 
+def _wrapped_call(wrap_controller, func):
+    """ Wrap calling to a function with a generator which needs to yield
+    exactly once.  The yield point will trigger calling the wrapped function
+    and return its ``_Result`` to the yield point.  The generator then needs
+    to finish (raise StopIteration) in order for the wrapped call to complete.
+    """
+    try:
+        next(wrap_controller)   # first yield
+    except StopIteration:
+        _raise_wrapfail(wrap_controller, "did not yield")
+    call_outcome = _Result.from_call(func)
+    try:
+        wrap_controller.send(call_outcome)
+        _raise_wrapfail(wrap_controller, "has second yield")
+    except StopIteration:
+        pass
+    return call_outcome.get_result()
+
+
+class _LegacyMultiCall(object):
+    """ execute a call into multiple python functions/methods. """
+
+    # XXX note that the __multicall__ argument is supported only
+    # for pytest compatibility reasons.  It was never officially
+    # supported there and is explicitely deprecated since 2.8
+    # so we can remove it soon, allowing to avoid the below recursion
+    # in execute() and simplify/speed up the execute loop.
+
+    def __init__(self, hook_impls, kwargs, specopts={}, hook=None):
+        self.hook = hook
+        self.hook_impls = hook_impls
+        self.caller_kwargs = kwargs  # come from _HookCaller.__call__()
+        self.caller_kwargs["__multicall__"] = self
+        self.specopts = hook.spec_opts if hook else specopts
+
+    def execute(self):
+        caller_kwargs = self.caller_kwargs
+        self.results = results = []
+        firstresult = self.specopts.get("firstresult")
+
+        while self.hook_impls:
+            hook_impl = self.hook_impls.pop()
+            try:
+                args = [caller_kwargs[argname] for argname in hook_impl.argnames]
+            except KeyError:
+                for argname in hook_impl.argnames:
+                    if argname not in caller_kwargs:
+                        raise HookCallError(
+                            "hook call must provide argument %r" % (argname,))
+            if hook_impl.hookwrapper:
+                return _wrapped_call(hook_impl.function(*args), self.execute)
+            res = hook_impl.function(*args)
+            if res is not None:
+                if firstresult:
+                    return res
+                results.append(res)
+
+        if not firstresult:
+            return results
+
+    def __repr__(self):
+        status = "%d meths" % (len(self.hook_impls),)
+        if hasattr(self, "results"):
+            status = ("%d results, " % len(self.results)) + status
+        return "<_MultiCall %s, kwargs=%r>" % (status, self.caller_kwargs)
+
+
 class _MultiCall(object):
     """Execute a call into multiple python functions/methods.
     """

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -28,7 +28,7 @@ def wrapper(arg1, arg2, arg3):
 
 
 @pytest.fixture(
-    params=[0, 1, 10, 100],
+    params=[10, 100],
     ids="hooks={}".format,
 )
 def hooks(request):
@@ -36,7 +36,7 @@ def hooks(request):
 
 
 @pytest.fixture(
-    params=[0, 1, 10, 100],
+    params=[10, 100],
     ids="wrappers={}".format,
 )
 def wrappers(request):

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -2,7 +2,7 @@
 Benchmarking and performance tests.
 """
 import pytest
-from pluggy import (_MultiCall, _LegacyMultiCall, HookImpl, HookspecMarker,
+from pluggy import (_multicall, _legacymulticall, HookImpl, HookspecMarker,
                     HookimplMarker)
 
 hookspec = HookspecMarker("example")
@@ -44,7 +44,7 @@ def wrappers(request):
 
 
 @pytest.fixture(
-    params=[_MultiCall, _LegacyMultiCall],
+    params=[_multicall, _legacymulticall],
     ids=lambda item: item.__name__
 )
 def callertype(request):
@@ -52,7 +52,7 @@ def callertype(request):
 
 
 def inner_exec(methods, callertype):
-    return MC(methods, {'arg1': 1, 'arg2': 2, 'arg3': 3}, callertype).execute()
+    return MC(methods, {'arg1': 1, 'arg2': 2, 'arg3': 3}, callertype)
 
 
 def test_hook_and_wrappers_speed(benchmark, hooks, wrappers, callertype):


### PR DESCRIPTION
For some weird reason the benchmark tests are turning out to be slightly slower for the `_multicall` cases?
I'm not sure if I'm testing something differently or if invoking 2 methods is faster then a single function?

I'm going to investigate deeper.