### PR TITLE
Fix #81: Stop using 'inspect.getargspec()'

### DIFF
--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -491,7 +491,7 @@ def varnames(func):
             return ()
 
     try:  # func MUST be a function or method here or we won't parse any args
-        spec = inspect.getargspec(func)
+        spec = _getargspec(func)
     except TypeError:
         return (), ()
 
@@ -657,6 +657,14 @@ class HookImpl(object):
         self.opts = hook_impl_opts
         self.plugin_name = plugin_name
         self.__dict__.update(hook_impl_opts)
+
+
+if hasattr(inspect, 'getfullargspec'):
+    def _getargspec(func):
+        return inspect.getfullargspec(func)
+else:
+    def _getargspec(func):
+        return inspect.getargspec(func)
 
 
 if hasattr(inspect, 'signature'):

--- a/tox.ini
+++ b/tox.ini
@@ -39,8 +39,6 @@ addopts=-rxsX
 norecursedirs=.tox ja .hg .env*
 filterwarnings =
   error
-  # inspect.getargspec() ignored, should be fixed in #81
-  ignore:inspect.getargspec().*deprecated
 
 [flake8]
 max-line-length=99


### PR DESCRIPTION
This function is deprecated and raises the warning.

    DeprecationWarning: inspect.getargspec() is deprecated, use
    inspect.signature() instead

While this suggests we use 'inspect.signature()', there's no reason to
use this instead of the 'inspect.getfullargspec()', which has almost
identical semantics to 'inspect.getargspec()' but handles kwargs-only
functions. For what we want though, this is a drop-in replacement.

Note that because 'inspect.getfullargspec()' isn't provided in Python
2.7, we may see slightly different behavior between Python 2 and 3 (e.g.
for the kwargs-only case above).  There's nothing we can do about this
without vendoring the entire function.