### PR TITLE
Fix #95: Resolve E741 errors

### DIFF
--- a/testing/test_hookrelay.py
+++ b/testing/test_hookrelay.py
@@ -24,8 +24,8 @@ def test_happypath(pm):
 
     plugin = Plugin()
     pm.register(plugin)
-    l = hook.hello(arg=3)
-    assert l == [4]
+    out = hook.hello(arg=3)
+    assert out == [4]
     assert not hasattr(hook, 'world')
     pm.unregister(plugin)
     assert hook.hello(arg=3) == []

--- a/testing/test_method_ordering.py
+++ b/testing/test_method_ordering.py
@@ -215,42 +215,42 @@ def test_load_setuptools_not_installed(monkeypatch, pm):
 
 
 def test_add_tracefuncs(he_pm):
-    l = []
+    out = []
 
     class api1(object):
         @hookimpl
         def he_method1(self):
-            l.append("he_method1-api1")
+            out.append("he_method1-api1")
 
     class api2(object):
         @hookimpl
         def he_method1(self):
-            l.append("he_method1-api2")
+            out.append("he_method1-api2")
 
     he_pm.register(api1())
     he_pm.register(api2())
 
     def before(hook_name, hook_impls, kwargs):
-        l.append((hook_name, list(hook_impls), kwargs))
+        out.append((hook_name, list(hook_impls), kwargs))
 
     def after(outcome, hook_name, hook_impls, kwargs):
-        l.append((outcome, hook_name, list(hook_impls), kwargs))
+        out.append((outcome, hook_name, list(hook_impls), kwargs))
 
     undo = he_pm.add_hookcall_monitoring(before, after)
 
     he_pm.hook.he_method1(arg=1)
-    assert len(l) == 4
-    assert l[0][0] == "he_method1"
-    assert len(l[0][1]) == 2
-    assert isinstance(l[0][2], dict)
-    assert l[1] == "he_method1-api2"
-    assert l[2] == "he_method1-api1"
-    assert len(l[3]) == 4
-    assert l[3][1] == l[0][0]
+    assert len(out) == 4
+    assert out[0][0] == "he_method1"
+    assert len(out[0][1]) == 2
+    assert isinstance(out[0][2], dict)
+    assert out[1] == "he_method1-api2"
+    assert out[2] == "he_method1-api1"
+    assert len(out[3]) == 4
+    assert out[3][1] == out[0][0]
 
     undo()
     he_pm.hook.he_method1(arg=1)
-    assert len(l) == 4 + 2
+    assert len(out) == 4 + 2
 
 
 def test_hook_tracing(he_pm):
@@ -268,18 +268,18 @@ def test_hook_tracing(he_pm):
             raise ValueError()
 
     he_pm.register(api1())
-    l = []
-    he_pm.trace.root.setwriter(l.append)
+    out = []
+    he_pm.trace.root.setwriter(out.append)
     undo = he_pm.enable_tracing()
     try:
         indent = he_pm.trace.root.indent
         he_pm.hook.he_method1(arg=1)
         assert indent == he_pm.trace.root.indent
-        assert len(l) == 2
-        assert 'he_method1' in l[0]
-        assert 'finish' in l[1]
+        assert len(out) == 2
+        assert 'he_method1' in out[0]
+        assert 'finish' in out[1]
 
-        l[:] = []
+        out[:] = []
         he_pm.register(api2())
 
         with pytest.raises(ValueError):

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -10,10 +10,10 @@ hookimpl = HookimplMarker("example")
 
 
 def test_uses_copy_of_methods():
-    l = [lambda: 42]
-    mc = _LegacyMultiCall(l, {})
+    out = [lambda: 42]
+    mc = _LegacyMultiCall(out, {})
     repr(mc)
-    l[:] = []
+    out[:] = []
     res = mc.execute()
     return res == 42
 
@@ -112,46 +112,46 @@ def test_call_none_is_no_result():
 
 
 def test_hookwrapper():
-    l = []
+    out = []
 
     @hookimpl(hookwrapper=True)
     def m1():
-        l.append("m1 init")
+        out.append("m1 init")
         yield None
-        l.append("m1 finish")
+        out.append("m1 finish")
 
     @hookimpl
     def m2():
-        l.append("m2")
+        out.append("m2")
         return 2
 
     res = MC([m2, m1], {})
     assert res == [2]
-    assert l == ["m1 init", "m2", "m1 finish"]
-    l[:] = []
+    assert out == ["m1 init", "m2", "m1 finish"]
+    out[:] = []
     res = MC([m2, m1], {}, {"firstresult": True})
     assert res == 2
-    assert l == ["m1 init", "m2", "m1 finish"]
+    assert out == ["m1 init", "m2", "m1 finish"]
 
 
 def test_hookwrapper_order():
-    l = []
+    out = []
 
     @hookimpl(hookwrapper=True)
     def m1():
-        l.append("m1 init")
+        out.append("m1 init")
         yield 1
-        l.append("m1 finish")
+        out.append("m1 finish")
 
     @hookimpl(hookwrapper=True)
     def m2():
-        l.append("m2 init")
+        out.append("m2 init")
         yield 2
-        l.append("m2 finish")
+        out.append("m2 finish")
 
     res = MC([m2, m1], {})
     assert res == []
-    assert l == ["m1 init", "m2 init", "m2 finish", "m1 finish"]
+    assert out == ["m1 init", "m2 init", "m2 finish", "m1 finish"]
 
 
 def test_hookwrapper_not_yield():
@@ -177,13 +177,13 @@ def test_hookwrapper_too_many_yield():
 
 @pytest.mark.parametrize("exc", [ValueError, SystemExit])
 def test_hookwrapper_exception(exc):
-    l = []
+    out = []
 
     @hookimpl(hookwrapper=True)
     def m1():
-        l.append("m1 init")
+        out.append("m1 init")
         yield None
-        l.append("m1 finish")
+        out.append("m1 finish")
 
     @hookimpl
     def m2():
@@ -191,4 +191,4 @@ def test_hookwrapper_exception(exc):
 
     with pytest.raises(exc):
         MC([m2, m1], {})
-    assert l == ["m1 init", "m1 finish"]
+    assert out == ["m1 init", "m1 finish"]

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -25,16 +25,16 @@ def test_pm(pm):
     assert pm.is_registered(a1)
     pm.register(a2, "hello")
     assert pm.is_registered(a2)
-    l = pm.get_plugins()
-    assert a1 in l
-    assert a2 in l
+    out = pm.get_plugins()
+    assert a1 in out
+    assert a2 in out
     assert pm.get_plugin('hello') == a2
     assert pm.unregister(a1) == a1
     assert not pm.is_registered(a1)
 
-    l = pm.list_name_plugin()
-    assert len(l) == 1
-    assert l == [("hello", a2)]
+    out = pm.list_name_plugin()
+    assert len(out) == 1
+    assert out == [("hello", a2)]
 
 
 def test_has_plugin(pm):
@@ -162,25 +162,25 @@ def test_register_historic(pm):
     pm.add_hookspecs(Hooks)
 
     pm.hook.he_method1.call_historic(kwargs=dict(arg=1))
-    l = []
+    out = []
 
     class Plugin(object):
         @hookimpl
         def he_method1(self, arg):
-            l.append(arg)
+            out.append(arg)
 
     pm.register(Plugin())
-    assert l == [1]
+    assert out == [1]
 
     class Plugin2(object):
         @hookimpl
         def he_method1(self, arg):
-            l.append(arg * 10)
+            out.append(arg * 10)
 
     pm.register(Plugin2())
-    assert l == [1, 10]
+    assert out == [1, 10]
     pm.hook.he_method1.call_historic(kwargs=dict(arg=12))
-    assert l == [1, 10, 120, 12]
+    assert out == [1, 10, 120, 12]
 
 
 def test_with_result_memorized(pm):
@@ -191,8 +191,8 @@ def test_with_result_memorized(pm):
     pm.add_hookspecs(Hooks)
 
     he_method1 = pm.hook.he_method1
-    he_method1.call_historic(lambda res: l.append(res), dict(arg=1))
-    l = []
+    he_method1.call_historic(lambda res: out.append(res), dict(arg=1))
+    out = []
 
     class Plugin(object):
         @hookimpl
@@ -200,7 +200,7 @@ def test_with_result_memorized(pm):
             return arg * 10
 
     pm.register(Plugin())
-    assert l == [10]
+    assert out == [10]
 
 
 def test_with_callbacks_immediately_executed(pm):
@@ -225,15 +225,15 @@ def test_with_callbacks_immediately_executed(pm):
         def he_method1(self, arg):
             return arg * 30
 
-    l = []
+    out = []
     pm.register(Plugin1())
     pm.register(Plugin2())
 
     he_method1 = pm.hook.he_method1
-    he_method1.call_historic(lambda res: l.append(res), dict(arg=1))
-    assert l == [20, 10]
+    he_method1.call_historic(lambda res: out.append(res), dict(arg=1))
+    assert out == [20, 10]
     pm.register(Plugin3())
-    assert l == [20, 10, 30]
+    assert out == [20, 10, 30]
 
 
 def test_register_historic_incompat_hookwrapper(pm):
@@ -244,12 +244,12 @@ def test_register_historic_incompat_hookwrapper(pm):
 
     pm.add_hookspecs(Hooks)
 
-    l = []
+    out = []
 
     class Plugin(object):
         @hookimpl(hookwrapper=True)
         def he_method1(self, arg):
-            l.append(arg)
+            out.append(arg)
 
     with pytest.raises(PluginValidationError):
         pm.register(Plugin())
@@ -266,8 +266,8 @@ def test_call_extra(pm):
     def he_method1(arg):
         return arg * 10
 
-    l = pm.hook.he_method1.call_extra([he_method1], dict(arg=1))
-    assert l == [10]
+    out = pm.hook.he_method1.call_extra([he_method1], dict(arg=1))
+    assert out == [10]
 
 
 def test_call_with_too_few_args(pm):
@@ -296,17 +296,17 @@ def test_subset_hook_caller(pm):
 
     pm.add_hookspecs(Hooks)
 
-    l = []
+    out = []
 
     class Plugin1(object):
         @hookimpl
         def he_method1(self, arg):
-            l.append(arg)
+            out.append(arg)
 
     class Plugin2(object):
         @hookimpl
         def he_method1(self, arg):
-            l.append(arg * 10)
+            out.append(arg * 10)
 
     class PluginNo(object):
         pass
@@ -316,26 +316,26 @@ def test_subset_hook_caller(pm):
     pm.register(plugin2)
     pm.register(plugin3)
     pm.hook.he_method1(arg=1)
-    assert l == [10, 1]
-    l[:] = []
+    assert out == [10, 1]
+    out[:] = []
 
     hc = pm.subset_hook_caller("he_method1", [plugin1])
     hc(arg=2)
-    assert l == [20]
-    l[:] = []
+    assert out == [20]
+    out[:] = []
 
     hc = pm.subset_hook_caller("he_method1", [plugin2])
     hc(arg=2)
-    assert l == [2]
-    l[:] = []
+    assert out == [2]
+    out[:] = []
 
     pm.unregister(plugin1)
     hc(arg=2)
-    assert l == []
-    l[:] = []
+    assert out == []
+    out[:] = []
 
     pm.hook.he_method1(arg=1)
-    assert l == [10]
+    assert out == [10]
 
 
 def test_multicall_deprecated(pm):

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -6,21 +6,21 @@ def test_simple():
     rootlogger = _TagTracer()
     log = rootlogger.get("pytest")
     log("hello")
-    l = []
-    rootlogger.setwriter(l.append)
+    out = []
+    rootlogger.setwriter(out.append)
     log("world")
-    assert len(l) == 1
-    assert l[0] == "world [pytest]\n"
+    assert len(out) == 1
+    assert out[0] == "world [pytest]\n"
     sublog = log.get("collection")
     sublog("hello")
-    assert l[1] == "hello [pytest:collection]\n"
+    assert out[1] == "hello [pytest:collection]\n"
 
 
 def test_indent():
     rootlogger = _TagTracer()
     log = rootlogger.get("1")
-    l = []
-    log.root.setwriter(lambda arg: l.append(arg))
+    out = []
+    log.root.setwriter(lambda arg: out.append(arg))
     log("hello")
     log.root.indent += 1
     log("line1")
@@ -32,8 +32,8 @@ def test_indent():
     log("line5")
     log.root.indent -= 1
     log("last")
-    assert len(l) == 7
-    names = [x[:x.rfind(' [')] for x in l]
+    assert len(out) == 7
+    names = [x[:x.rfind(' [')] for x in out]
     assert names == [
         'hello', '  line1', '  line2',
         '    line3', '    line4', '  line5', 'last']
@@ -57,12 +57,12 @@ def test_setprocessor():
     log = rootlogger.get("1")
     log2 = log.get("2")
     assert log2.tags == tuple("12")
-    l = []
-    rootlogger.setprocessor(tuple("12"), lambda *args: l.append(args))
+    out = []
+    rootlogger.setprocessor(tuple("12"), lambda *args: out.append(args))
     log("not seen")
     log2("seen")
-    assert len(l) == 1
-    tags, args = l[0]
+    assert len(out) == 1
+    tags, args = out[0]
     assert "1" in tags
     assert "2" in tags
     assert args == ("seen",)
@@ -77,13 +77,13 @@ def test_setmyprocessor():
     rootlogger = _TagTracer()
     log = rootlogger.get("1")
     log2 = log.get("2")
-    l = []
-    log2.setmyprocessor(lambda *args: l.append(args))
+    out = []
+    log2.setmyprocessor(lambda *args: out.append(args))
     log("not seen")
-    assert not l
+    assert not out
     log2(42)
-    assert len(l) == 1
-    tags, args = l[0]
+    assert len(out) == 1
+    tags, args = out[0]
     assert "1" in tags
     assert "2" in tags
     assert args == (42,)


### PR DESCRIPTION
Fix #95: Resolve E741 errors
    
The E741 (Ambiguous variable name) error has been enabled in flake8 3.5.0, which imports pycodestyle 2.1.0 [1]. Resolve the warnings.
    
[1] https://github.com/PyCQA/pycodestyle/issues/598