### PR TITLE
Self contained call loops

### DIFF
--- a/testing/test_method_ordering.py
+++ b/testing/test_method_ordering.py
@@ -290,15 +290,17 @@ def test_hook_tracing(he_pm):
         undo()
 
 
-def test_prefix_hookimpl():
+@pytest.mark.parametrize('include_hookspec', [True, False])
+def test_prefix_hookimpl(include_hookspec):
     pm = PluginManager(hookspec.project_name, "hello_")
 
-    class HookSpec(object):
-        @hookspec
-        def hello_myhook(self, arg1):
-            """ add to arg1 """
+    if include_hookspec:
+        class HookSpec(object):
+            @hookspec
+            def hello_myhook(self, arg1):
+                """ add to arg1 """
 
-    pm.add_hookspecs(HookSpec)
+        pm.add_hookspecs(HookSpec)
 
     class Plugin(object):
         def hello_myhook(self, arg1):

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -26,7 +26,7 @@ def MC(methods, kwargs, firstresult=False):
         hookfuncs.append(f)
         if '__multicall__' in f.argnames:
             caller = _legacymulticall
-    return caller(hookfuncs, kwargs, specopts={"firstresult": firstresult})
+    return caller(hookfuncs, kwargs, firstresult=firstresult)
 
 
 def test_call_passing():
@@ -105,7 +105,7 @@ def test_call_none_is_no_result():
     def m2():
         return None
 
-    res = MC([m1, m2], {}, {"firstresult": True})
+    res = MC([m1, m2], {}, firstresult=True)
     assert res == 1
     res = MC([m1, m2], {}, {})
     assert res == [1]
@@ -129,7 +129,7 @@ def test_hookwrapper():
     assert res == [2]
     assert out == ["m1 init", "m2", "m1 finish"]
     out[:] = []
-    res = MC([m2, m1], {}, {"firstresult": True})
+    res = MC([m2, m1], {}, firstresult=True)
     assert res == 2
     assert out == ["m1 init", "m2", "m1 finish"]
 


### PR DESCRIPTION
This fixes #99 as well as removes any direct references to `_HookCaller` inside of the multi call loops.
This makes the call loops fully self contained without requiring any knowledge of overlying abstractions.