### PR TITLE
Avoid TypeError in call_historic()

### DIFF
--- a/pluggy/__init__.py
+++ b/pluggy/__init__.py
@@ -626,6 +626,8 @@ class _HookCaller(object):
         self._call_history.append((kwargs or {}, proc))
         # historizing hooks don't return results
         res = self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
+        if proc is None:
+            return
         for x in res or []:
             proc(x)
 


### PR DESCRIPTION
The default argument for `proc` in `_HookCaller.call_historic()` is `None`.  No attempt should be made to call it.