### PR TITLE
Fix docs references

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -7,8 +7,8 @@ Api Reference
     :show-inheritance:
 
 
-.. automethod:: pluggy._Result.get_result
+.. automethod:: pluggy.callers._Result.get_result
 
-.. automethod:: pluggy._Result.force_result
+.. automethod:: pluggy.callers._Result.force_result
 
-.. automethod:: pluggy._HookCaller.call_extra
+.. automethod:: pluggy.hooks._HookCaller.call_extra

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -239,11 +239,11 @@ be implemented as generator function with a single ``yield`` in its body:
         if config.use_defaults:
             outcome.force_result(defaults)
 
-The generator is `sent`_ a :py:class:`pluggy._Result` object which can
+The generator is `sent`_ a :py:class:`pluggy.callers._Result` object which can
 be assigned in the ``yield`` expression and used to override or inspect
 the final result(s) returned back to the caller using the
-:py:meth:`~pluggy._Result.force_result` or
-:py:meth:`~pluggy._Result.get_result` methods.
+:py:meth:`~pluggy.callers._Result.force_result` or
+:py:meth:`~pluggy.callers._Result.get_result` methods.
 
 .. note::
     Hook wrappers can **not** return results (as per generator function


### PR DESCRIPTION
Some reference fixes after moving `_Result` into the `callers` module.
Can't come in until #117 has landed.