### PR TITLE
Add .plugin member to PluginValidationError to access failing plugin

### DIFF
--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -4,7 +4,10 @@ from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 
 
 class PluginValidationError(Exception):
-    """ plugin failed validation. """
+    """ plugin failed validation. 
+
+    :param object plugin: the plugin which failed validation, may be a module or an arbitrary object.
+    """
 
     def __init__(self, plugin, message):
         self.plugin = plugin

--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -6,6 +6,10 @@ from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 class PluginValidationError(Exception):
     """ plugin failed validation. """
 
+    def __init__(self, plugin, message):
+        self.plugin = plugin
+        super(Exception, self).__init__(message)
+
 
 class PluginManager(object):
     """ Core Pluginmanager class which manages registration
@@ -178,6 +182,7 @@ class PluginManager(object):
     def _verify_hook(self, hook, hookimpl):
         if hook.is_historic() and hookimpl.hookwrapper:
             raise PluginValidationError(
+                hookimpl.plugin,
                 "Plugin %r\nhook %r\nhistoric incompatible to hookwrapper" %
                 (hookimpl.plugin_name, hook.name))
 
@@ -185,6 +190,7 @@ class PluginManager(object):
         notinspec = set(hookimpl.argnames) - set(hook.argnames)
         if notinspec:
             raise PluginValidationError(
+                hookimpl.plugin,
                 "Plugin %r for hook %r\nhookimpl definition: %s\n"
                 "Argument(s) %s are declared in the hookimpl but "
                 "can not be found in the hookspec" %
@@ -202,6 +208,7 @@ class PluginManager(object):
                     for hookimpl in (hook._wrappers + hook._nonwrappers):
                         if not hookimpl.optionalhook:
                             raise PluginValidationError(
+                                hookimpl.plugin,
                                 "unknown hook %r in plugin %r" %
                                 (name, hookimpl.plugin))
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -103,9 +103,12 @@ def test_register_mismatch_method(he_pm):
         def he_method_notexists(self):
             pass
 
-    he_pm.register(hello())
-    with pytest.raises(PluginValidationError):
+    plugin = hello()
+
+    he_pm.register(plugin)
+    with pytest.raises(PluginValidationError) as excinfo:
         he_pm.check_pending()
+    assert excinfo.value.plugin is plugin
 
 
 def test_register_mismatch_arg(he_pm):
@@ -114,8 +117,11 @@ def test_register_mismatch_arg(he_pm):
         def he_method1(self, qlwkje):
             pass
 
-    with pytest.raises(PluginValidationError):
-        he_pm.register(hello())
+    plugin = hello()
+
+    with pytest.raises(PluginValidationError) as excinfo:
+        he_pm.register(plugin)
+    assert excinfo.value.plugin is plugin
 
 
 def test_register(pm):


### PR DESCRIPTION
The goal of this is to be able to call `.check_pending()` catching the exception, then unregister the plugin and print a message, allowing the program to continue without that plugin. If there is already a way to do this, I haven't found it.