### PR TITLE
support adding per implementation warnings for hookspecs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -384,6 +384,21 @@ dynamically loaded plugins.
 For more info see :ref:`call_historic`.
 
 
+Warnings on hook implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As projects evolve new hooks may be introduced and/or deprecated.
+
+if a hookspec specifies a ``warn_on_impl``, pluggy will trigger it for any plugin implementing the hook.
+
+
+.. code-block:: python
+
+    @hookspec(warn_on_impl=DeprecationWarning("oldhook is deprecated and will be removed soon"))
+    def oldhook():
+        pass
+
+
 .. links
 .. _@contextlib.contextmanager:
     https://docs.python.org/3.6/library/contextlib.html#contextlib.contextmanager

--- a/pluggy/hooks.py
+++ b/pluggy/hooks.py
@@ -17,7 +17,7 @@ class HookspecMarker(object):
     def __init__(self, project_name):
         self.project_name = project_name
 
-    def __call__(self, function=None, firstresult=False, historic=False):
+    def __call__(self, function=None, firstresult=False, historic=False, warn_on_impl=None):
         """ if passed a function, directly sets attributes on the function
         which will make it discoverable to add_hookspecs().  If passed no
         function, returns a decorator which can be applied to a function
@@ -35,7 +35,8 @@ class HookspecMarker(object):
             if historic and firstresult:
                 raise ValueError("cannot have a historic firstresult hook")
             setattr(func, self.project_name + "_spec",
-                    dict(firstresult=firstresult, historic=historic))
+                    dict(firstresult=firstresult, historic=historic,
+                         warn_on_impl=warn_on_impl,))
             return func
 
         if function is not None:
@@ -195,6 +196,7 @@ class _HookCaller(object):
         self.spec_opts.update(spec_opts)
         if spec_opts.get("historic"):
             self._call_history = []
+        self.warn_on_impl = spec_opts.get('warn_on_impl')
 
     def is_historic(self):
         return hasattr(self, "_call_history")

--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -1,12 +1,23 @@
 import inspect
 from . import _tracing
 from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
+import warnings
+
+
+def _warn_for_function(warning, function):
+    warnings.warn_explicit(
+        warning,
+        type(warning),
+        lineno=function.__code__.co_firstlineno,
+        filename=function.__code__.co_filename,
+    )
 
 
 class PluginValidationError(Exception):
-    """ plugin failed validation. 
+    """ plugin failed validation.
 
-    :param object plugin: the plugin which failed validation, may be a module or an arbitrary object.
+    :param object plugin: the plugin which failed validation,
+        may be a module or an arbitrary object.
     """
 
     def __init__(self, plugin, message):
@@ -188,7 +199,8 @@ class PluginManager(object):
                 hookimpl.plugin,
                 "Plugin %r\nhook %r\nhistoric incompatible to hookwrapper" %
                 (hookimpl.plugin_name, hook.name))
-
+        if hook.warn_on_impl:
+            _warn_for_function(hook.warn_on_impl, hookimpl.function)
         # positional arg checking
         notinspec = set(hookimpl.argnames) - set(hook.argnames)
         if notinspec:


### PR DESCRIPTION
this will be used later on in pytest to deprecate hooks we dont really use/support anymore so we can remove them in future

this can also be used to do futurewarnings for experimental hooks