### PR TITLE
Add HookCaller.clear_history()

### DIFF
--- a/pluggy/hooks.py
+++ b/pluggy/hooks.py
@@ -301,6 +301,7 @@ class _HookCaller(object):
         savegames, and not notifying plugins of events that occurred prior
         to loading the current one.
         """
+        self._call_history.clear()
 
 
 class HookImpl(object):

--- a/pluggy/hooks.py
+++ b/pluggy/hooks.py
@@ -293,6 +293,14 @@ class _HookCaller(object):
                 res = self._hookexec(self, [method], kwargs)
                 if res and proc is not None:
                     proc(res[0])
+    
+    def clear_history(self):
+        """Clear the call history.  Only historic calls made after the most
+        recent call to this method will be replayed onto newly-registered
+        plugins.  Helpful for reusing plugin managers between, for example,
+        savegames, and not notifying plugins of events that occurred prior
+        to loading the current one.
+        """
 
 
 class HookImpl(object):


### PR DESCRIPTION
Say you're making a game which can have multiple save-states.  Keeping a reference to the plugin manager along with the save state, for whatever reason, is not an option.  You don't want to notify plugins of historic events that occurred outside the scope of the current save-state, which would do nothing and waste a significant amount of memory and time at best and, at worst, could corrupt the save-state currently loaded.    It would be useful to be able to clear the call history of several functions relying on the context of the current save-state when a new save is loaded, or when the player returns to the main menu.

Or say you're playing with a library that implements reconnection logic, and there's a hook it calls when it connects.  You do your initialization in that hook, but there's no guarantee it will only be called once (for example, if the connection is lost and then regained, it will be called again).  You don't want to waste memory keeping around the arguments for previous calls to that function (which may be somewhat large) or time by calling the plugin hooks, which may take a significant amount of time to execute, more than once.  It would be useful to be able to clear the call history of that initialization function when the connection is lost.

Using myhook._call_history.clear() from user code is going to draw some funny looks from anyone reviewing it, and probably isn't going to be guaranteed to work, for example, if HookCaller gets converted to Cython.  I admit that the use cases for this are niche, but I think they're significant enough that people might actually use this if it was added.