### PR TITLE
Document self arg and exception handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,9 @@ A definitive example
 
 .. badges
 .. |pypi| image:: https://img.shields.io/pypi/v/pluggy.svg
-    :target: https://pypi.python.org/pypi/pluggy
+    :target: https://pypi.org/pypi/pluggy
 .. |versions| image:: https://img.shields.io/pypi/pyversions/pluggy.svg
-    :target: https://pypi.python.org/pypi/pluggy
+    :target: https://pypi.org/pypi/pluggy
 .. |travis| image:: https://img.shields.io/travis/pytest-dev/pluggy/master.svg
     :target: https://travis-ci.org/pytest-dev/pluggy
 .. |appveyor| image:: https://img.shields.io/appveyor/ci/pytestbot/pluggy/master.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -517,25 +517,6 @@ if a hookspec specifies a ``warn_on_impl``, pluggy will trigger it for any plugi
     def oldhook():
         pass
 
-
-.. links
-.. _@contextlib.contextmanager:
-    https://docs.python.org/3.6/library/contextlib.html#contextlib.contextmanager
-.. _pytest_cmdline_main:
-    https://github.com/pytest-dev/pytest/blob/master/_pytest/hookspec.py#L80
-.. _hookspec module:
-    https://github.com/pytest-dev/pytest/blob/master/_pytest/hookspec.py
-.. _Writing hook functions:
-    http://doc.pytest.org/en/latest/writing_plugins.html#writing-hook-functions
-.. _hookwrapper:
-    http://doc.pytest.org/en/latest/writing_plugins.html#hookwrapper-executing-around-other-hooks
-.. _hook function ordering:
-    http://doc.pytest.org/en/latest/writing_plugins.html#hook-function-ordering-call-example
-.. _first result:
-    http://doc.pytest.org/en/latest/writing_plugins.html#firstresult-stop-at-first-non-none-result
-.. _sent:
-    https://docs.python.org/3/reference/expressions.html#generator.send
-
 .. _manage:
 
 The Plugin registry
@@ -861,6 +842,22 @@ in your project you should thus use a dependency restriction like
 
 
 .. hyperlinks
+.. _@contextlib.contextmanager:
+    https://docs.python.org/3.6/library/contextlib.html#contextlib.contextmanager
+.. _pytest_cmdline_main:
+    https://github.com/pytest-dev/pytest/blob/master/_pytest/hookspec.py#L80
+.. _hookspec module:
+    https://github.com/pytest-dev/pytest/blob/master/_pytest/hookspec.py
+.. _Writing hook functions:
+    http://doc.pytest.org/en/latest/writing_plugins.html#writing-hook-functions
+.. _hookwrapper:
+    http://doc.pytest.org/en/latest/writing_plugins.html#hookwrapper-executing-around-other-hooks
+.. _hook function ordering:
+    http://doc.pytest.org/en/latest/writing_plugins.html#hook-function-ordering-call-example
+.. _first result:
+    http://doc.pytest.org/en/latest/writing_plugins.html#firstresult-stop-at-first-non-none-result
+.. _sent:
+    https://docs.python.org/3/reference/expressions.html#generator.send
 .. _pytest:
     https://pytest.org
 .. _request-response pattern:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -451,6 +451,11 @@ whereas this is not:
     def myhook(config, args, extra_arg):
         print(args)
 
+.. note::
+    The one exception to this rule (that a *hookspec* must have as least as
+    many arguments as its *hookimpls*) is the conventional `self`_ arg; this
+    is always ignored when *hookimpls* are defined as `methods`_.
+
 .. _firstresult:
 
 First result only
@@ -823,6 +828,10 @@ in your project you should thus use a dependency restriction like
     https://github.com/pytest-dev/pluggy/blob/master/tox.ini#L2
 .. _200+ plugins:
     http://plugincompat.herokuapp.com/
+.. _self:
+    https://docs.python.org/3.6/tutorial/classes.html#random-remarks
+.. _methods:
+    https://docs.python.org/3.6/tutorial/classes.html#method-objects
 
 
 .. Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -707,7 +707,7 @@ point:
     class Plugin2(object):
         @hookimpl
         def myhook(self, args):
-            raise RunTimeError
+            raise RuntimeError
 
     class Plugin3(object):
         @hookimpl


### PR DESCRIPTION
Resolves #128 and switches our `pypi` links to warehouse.
Tossed in docs for #123 as well.