### PR TITLE
Deprecate `proc` kwarg to call_historic()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -706,20 +706,33 @@ using the :py:meth:`pluggy._HookCaller.call_historic()` method:
 
 .. code-block:: python
 
+    def callback(result):
+        print("historic call result is {result}".format(result=result))
+
     # call with history; no results returned
-    pm.hook.myhook.call_historic(config=config, args=sys.argv)
+    pm.hook.myhook.call_historic(
+        config=config, args=sys.argv,
+        result_callback=callback
+    )
 
     # ... more of our program ...
 
     # late loading of some plugin
     import mylateplugin
 
-    # historic call back is done here
+    # historic callback is invoked here
     pm.register(mylateplugin)
 
 Note that if you ``call_historic()`` the ``_HookCaller`` (and thus your
 calling code) can not receive results back from the underlying *hookimpl*
-functions.
+functions. Instead you can provide a *callback* for processing results
+(like the ``callback`` function above) which will be called as each
+new plugin is registered.
+
+.. note::
+    *historic* calls are incompatible with :ref:`firstresult` marked
+    hooks since only the first registered plugin's hook(s) would
+    ever be called.
 
 Calling with extras
 -------------------

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -217,7 +217,7 @@ def test_with_result_memorized(pm, result_callback):
     pm.register(Plugin1())
 
     he_method1 = pm.hook.he_method1
-    he_method1.call_historic(proc=callback, kwargs=dict(arg=1))
+    he_method1.call_historic(result_callback=callback, kwargs=dict(arg=1))
 
     class Plugin2(object):
         @hookimpl
@@ -399,3 +399,20 @@ def example_hook():
     assert getattr(pm.hook, 'example_hook', None)  # conftest.example_hook should be collected
     assert pm.parse_hookimpl_opts(conftest, 'example_blah') is None
     assert pm.parse_hookimpl_opts(conftest, 'example_hook') == {}
+
+
+def test_callhistoric_proc_deprecated(pm):
+    """``proc`` kwarg to `PluginMananger.call_historic()` is now officially
+    deprecated.
+    """
+    class P1(object):
+        @hookspec(historic=True)
+        @hookimpl
+        def m(self, x):
+            pass
+
+    p1 = P1()
+    pm.add_hookspecs(p1)
+    pm.register(p1)
+    with pytest.deprecated_call():
+        pm.hook.m.call_historic(kwargs=dict(x=10), proc=lambda res: res)


### PR DESCRIPTION
It's a bad name, use `result_callback` instead.

Resolves #120