### PR TITLE
Deprecate implprefix

### DIFF
--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -40,7 +40,7 @@ class PluginManager(object):
     """
 
     def __init__(self, project_name, implprefix=None):
-        """ if implprefix is given implementation functions
+        """If ``implprefix`` is given implementation functions
         will be recognized if their name matches the implprefix. """
         self.project_name = project_name
         self._name2plugin = {}
@@ -48,6 +48,12 @@ class PluginManager(object):
         self._plugin_distinfo = []
         self.trace = _tracing.TagTracer().get("pluginmanage")
         self.hook = _HookRelay(self.trace.root.get("hook"))
+        if implprefix is not None:
+            warnings.warn(
+                "Support for the `implprefix` arg is now deprecated and will "
+                "be removed in an upcoming release. Please use HookimplMarker.",
+                DeprecationWarning
+            )
         self._implprefix = implprefix
         self._inner_hookexec = lambda hook, methods, kwargs: \
             hook.multicall(
@@ -106,7 +112,14 @@ class PluginManager(object):
         if res is not None and not isinstance(res, dict):
             # false positive
             res = None
+        # TODO: remove when we drop implprefix in 1.0
         elif res is None and self._implprefix and name.startswith(self._implprefix):
+            _warn_for_function(
+                DeprecationWarning(
+                    "The `implprefix` system is deprecated please decorate "
+                    "this function using an instance of HookimplMarker."),
+                method
+            )
             res = {}
         return res
 

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -124,3 +124,15 @@ def test_result_deprecated():
     r = _Result(10, None)
     with pytest.deprecated_call():
         assert r.result == 10
+
+
+def test_implprefix_deprecated():
+    with pytest.deprecated_call():
+        pm = PluginManager('blah', implprefix='blah_')
+
+    class Plugin:
+        def blah_myhook(self, arg1):
+            return arg1
+
+    with pytest.deprecated_call():
+        pm.register(Plugin())

--- a/testing/test_method_ordering.py
+++ b/testing/test_method_ordering.py
@@ -291,7 +291,8 @@ def test_hook_tracing(he_pm):
 
 @pytest.mark.parametrize('include_hookspec', [True, False])
 def test_prefix_hookimpl(include_hookspec):
-    pm = PluginManager(hookspec.project_name, "hello_")
+    with pytest.deprecated_call():
+        pm = PluginManager(hookspec.project_name, "hello_")
 
     if include_hookspec:
         class HookSpec(object):
@@ -305,14 +306,16 @@ def test_prefix_hookimpl(include_hookspec):
         def hello_myhook(self, arg1):
             return arg1 + 1
 
-    pm.register(Plugin())
-    pm.register(Plugin())
+    with pytest.deprecated_call():
+        pm.register(Plugin())
+        pm.register(Plugin())
     results = pm.hook.hello_myhook(arg1=17)
     assert results == [18, 18]
 
 
 def test_prefix_hookimpl_dontmatch_module():
-    pm = PluginManager(hookspec.project_name, "hello_")
+    with pytest.deprecated_call():
+        pm = PluginManager(hookspec.project_name, "hello_")
 
     class BadPlugin(object):
         hello_module = __import__('email')

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -393,12 +393,14 @@ def example_hook():
 """)
     exec(src, conftest.__dict__)
     conftest.example_blah = types.ModuleType("example_blah")
-    name = pm.register(conftest)
+    with pytest.deprecated_call():
+        name = pm.register(conftest)
     assert name == 'conftest'
     assert getattr(pm.hook, 'example_blah', None) is None
     assert getattr(pm.hook, 'example_hook', None)  # conftest.example_hook should be collected
-    assert pm.parse_hookimpl_opts(conftest, 'example_blah') is None
-    assert pm.parse_hookimpl_opts(conftest, 'example_hook') == {}
+    with pytest.deprecated_call():
+        assert pm.parse_hookimpl_opts(conftest, 'example_blah') is None
+        assert pm.parse_hookimpl_opts(conftest, 'example_hook') == {}
 
 
 def test_callhistoric_proc_deprecated(pm):


### PR DESCRIPTION
Pertains to starting work on #116.
I'll have a corresponding PR to `pytest` to ensure the warning is avoided - turned out it's a trivial change.