### PR TITLE
Add HookImpl.__repr__

### DIFF
--- a/pluggy/hooks.py
+++ b/pluggy/hooks.py
@@ -315,3 +315,9 @@ class HookImpl(object):
         self.opts = hook_impl_opts
         self.plugin_name = plugin_name
         self.__dict__.update(hook_impl_opts)
+
+    def __repr__(self):
+        return "<HookImpl plugin_name=%r, plugin_file=%r>" % (
+            self.plugin_name,
+            self.plugin.__file__,
+        )

--- a/pluggy/hooks.py
+++ b/pluggy/hooks.py
@@ -317,7 +317,7 @@ class HookImpl(object):
         self.__dict__.update(hook_impl_opts)
 
     def __repr__(self):
-        return "<HookImpl plugin_name=%r, plugin_file=%r>" % (
+        return "<HookImpl plugin_name=%r, plugin=%r>" % (
             self.plugin_name,
-            self.plugin.__file__,
+            self.plugin,
         )

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -117,3 +117,20 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
         warning = warns[-1]
         assert issubclass(warning.category, Warning)
         assert "Argument(s) ('arg2',)" in str(warning.message)
+
+
+def test_repr():
+    class Plugin:
+        @hookimpl
+        def myhook():
+            raise NotImplementedError()
+
+    pm = PluginManager(hookspec.project_name)
+
+    plugin = Plugin()
+    pname = pm.register(plugin)
+    assert repr(pm.hook.myhook._nonwrappers[0]) == (
+        "<HookImpl plugin_name=%r, plugin=%r>" % (
+            pname,
+            plugin,
+        ))


### PR DESCRIPTION
This is helpful when debugging hooks being called.

Example:

> <HookImpl plugin_name='testmon', plugin_file='/path/to/plugin.py'>

Using `"<HookImpl plugin=%r>" % (self.plugin,)` instead would result in:

> <HookImpl plugin=<module 'testmon.tox_testmon' from '/path/to/plugin.py'>>