### PR TITLE
WIP:  Factor out pkg_resources for importlib_metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-        python_version: python3.6
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.0.0
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+import importlib_metadata
 
 
 extensions = [
@@ -20,14 +20,13 @@ master_doc = "index"
 
 # General information about the project.
 
-dist = pkg_resources.get_distribution("pluggy")
-project = dist.project_name
+project = "pluggy"
 copyright = u"2016, Holger Krekel"
 author = "Holger Krekel"
 
-release = dist.version
+release = importlib_metadata.version(project)
 # The short X.Y version.
-version = u".".join(dist.version.split(".")[:2])
+version = u".".join(release.split(".")[:2])
 
 
 language = None

--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -1,4 +1,5 @@
 import inspect
+import importlib_metadata
 from . import _tracing
 from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 import warnings
@@ -254,25 +255,14 @@ class PluginManager(object):
     def load_setuptools_entrypoints(self, entrypoint_name):
         """ Load modules from querying the specified setuptools entrypoint name.
         Return the number of loaded plugins. """
-        from pkg_resources import (
-            iter_entry_points,
-            DistributionNotFound,
-            VersionConflict,
-        )
-
-        for ep in iter_entry_points(entrypoint_name):
+        for ep in importlib_metadata.entry_points().get(entrypoint_name, ()):
             # is the plugin registered or blocked?
             if self.get_plugin(ep.name) or self.is_blocked(ep.name):
                 continue
             try:
                 plugin = ep.load()
-            except DistributionNotFound:
+            except (ImportError, AttributeError):
                 continue
-            except VersionConflict as e:
-                raise PluginValidationError(
-                    plugin=None,
-                    message="Plugin %r could not be loaded: %s!" % (ep.name, e),
-                )
             self.register(plugin, name=ep.name)
             self._plugin_distinfo.append((plugin, ep.dist))
         return len(self._plugin_distinfo)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        install_requires=["importlib-metadata>=0.8"],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],


### PR DESCRIPTION
Using a hacked up version of pytest this speeds up `pytest --help` by 26%:

```diff
diff --git a/src/_pytest/assertion/rewrite.py b/src/_pytest/assertion/rewrite.py
index 301bdedc..cdde4ab6 100644
--- a/src/_pytest/assertion/rewrite.py
+++ b/src/_pytest/assertion/rewrite.py
@@ -316,6 +316,7 @@ class AssertionRewritingHook(object):
         Ensure package resources can be loaded from this loader. May be called
         multiple times, as the operation is idempotent.
         """
+        return
         try:
             import pkg_resources
 
diff --git a/src/_pytest/config/__init__.py b/src/_pytest/config/__init__.py
index 3943f847..0db4d254 100644
--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -14,7 +14,6 @@ import warnings
 
 import py
 import six
-from pkg_resources import parse_version
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy import PluginManager
@@ -739,6 +738,7 @@ class Config(object):
         modules or packages in the distribution package for
         all pytest plugins.
         """
+        return
         import pkg_resources
 
         self.pluginmanager.rewrite_hook = hook
@@ -814,6 +814,7 @@ class Config(object):
                 raise
 
     def _checkversion(self):
+        return
         import pytest
 
         minver = self.inicfg.get("minversion", None)
diff --git a/src/_pytest/outcomes.py b/src/_pytest/outcomes.py
index 14c6e9ab..dfbcb152 100644
--- a/src/_pytest/outcomes.py
+++ b/src/_pytest/outcomes.py
@@ -173,6 +173,7 @@ def importorskip(modname, minversion=None, reason=None):
     verattr = getattr(mod, "__version__", None)
     if minversion is not None:
         try:
+            raise Skipped('wat')
             from pkg_resources import parse_version as pv
         except ImportError:
             raise Skipped(
```

(Using **_best of 5_**)

```console
$ # before
$ time pytest --help > /dev/null

real	0m0.377s
user	0m0.362s
sys	0m0.012s
```

```console
$ # after
$ time pytest --help > /dev/null

real	0m0.276s
user	0m0.253s
sys	0m0.016s
```