### PR TITLE
Fix method name `add_hookspecs` in docstring

### DIFF
--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -29,7 +29,7 @@ class PluginManager(object):
     """ Core Pluginmanager class which manages registration
     of plugin objects and 1:N hook calling.
 
-    You can register new hooks by calling ``add_hookspec(module_or_class)``.
+    You can register new hooks by calling ``add_hookspecs(module_or_class)``.
     You can register plugin objects (which contain hooks) by calling
     ``register(plugin)``.  The Pluginmanager is initialized with a
     prefix that is searched for in the names of the dict of registered


### PR DESCRIPTION
Correct the method name `add_hookspec` to `add_hookspecs` in the docstring of the `PluginManager` class.