### PR TITLE
Switch to importlib-metadata

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - C:\Python35\python -m tox
+  - C:\Python35\Scripts\tox
 
 # We don't deploy anything on tags with AppVeyor, we use Travis instead, so we
 # might as well save resources

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+import importlib_metadata
 
 
 extensions = [
@@ -20,14 +20,13 @@ master_doc = "index"
 
 # General information about the project.
 
-dist = pkg_resources.get_distribution("pluggy")
-project = dist.project_name
+project = "pluggy"
 copyright = u"2016, Holger Krekel"
 author = "Holger Krekel"
 
-release = dist.version
+release = importlib_metadata.version(project)
 # The short X.Y version.
-version = u".".join(dist.version.split(".")[:2])
+version = u".".join(release.split(".")[:2])
 
 
 language = None

--- a/pluggy/manager.py
+++ b/pluggy/manager.py
@@ -286,10 +286,7 @@ class PluginManager(object):
                 # is the plugin registered or blocked?
                 if self.get_plugin(ep.name) or self.is_blocked(ep.name):
                     continue
-                try:
-                    plugin = ep.load()
-                except (ImportError, AttributeError):
-                    continue
+                plugin = ep.load()
                 self.register(plugin, name=ep.name)
                 self._plugin_distinfo.append((plugin, DistFacade(dist)))
                 count += 1

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        install_requires=["importlib-metadata>=0.9"],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -471,7 +471,12 @@ def test_load_setuptools_instantiation(monkeypatch, pm):
     assert num == 1
     plugin = pm.get_plugin("myname")
     assert plugin.x == 42
-    assert pm.list_plugin_distinfo() == [(plugin, dist)]
+    ret = pm.list_plugin_distinfo()
+    # poor man's `assert ret == [(plugin, mock.ANY)]`
+    assert len(ret) == 1
+    assert len(ret[0]) == 2
+    assert ret[0][0] == plugin
+    assert ret[0][1]._dist == dist
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 0  # no plugin loaded by this call
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -3,7 +3,7 @@
 """
 import pytest
 import types
-import sys
+import importlib_metadata
 from pluggy import (
     PluginManager,
     PluginValidationError,
@@ -447,62 +447,33 @@ def example_hook():
 
 
 def test_load_setuptools_instantiation(monkeypatch, pm):
-    pkg_resources = pytest.importorskip("pkg_resources")
+    class EntryPoint(object):
+        name = "myname"
+        group = "hello"
+        value = "myname:foo"
 
-    def my_iter(group, name=None):
-        assert group == "hello"
+        def load(self):
+            class PseudoPlugin(object):
+                x = 42
 
-        class EntryPoint(object):
-            name = "myname"
-            dist = None
+            return PseudoPlugin()
 
-            def load(self):
-                class PseudoPlugin(object):
-                    x = 42
+    class Distribution(object):
+        entry_points = (EntryPoint(),)
 
-                return PseudoPlugin()
+    dist = Distribution()
 
-        return iter([EntryPoint()])
+    def my_distributions():
+        return (dist,)
 
-    monkeypatch.setattr(pkg_resources, "iter_entry_points", my_iter)
+    monkeypatch.setattr(importlib_metadata, "distributions", my_distributions)
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 1
     plugin = pm.get_plugin("myname")
     assert plugin.x == 42
-    assert pm.list_plugin_distinfo() == [(plugin, None)]
+    assert pm.list_plugin_distinfo() == [(plugin, dist)]
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 0  # no plugin loaded by this call
-
-
-def test_load_setuptools_version_conflict(monkeypatch, pm):
-    """Check that we properly handle a VersionConflict problem when loading entry points"""
-    pkg_resources = pytest.importorskip("pkg_resources")
-
-    def my_iter(group, name=None):
-        assert group == "hello"
-
-        class EntryPoint(object):
-            name = "myname"
-            dist = None
-
-            def load(self):
-                raise pkg_resources.VersionConflict("Some conflict")
-
-        return iter([EntryPoint()])
-
-    monkeypatch.setattr(pkg_resources, "iter_entry_points", my_iter)
-    with pytest.raises(
-        PluginValidationError,
-        match="Plugin 'myname' could not be loaded: Some conflict!",
-    ):
-        pm.load_setuptools_entrypoints("hello")
-
-
-def test_load_setuptools_not_installed(monkeypatch, pm):
-    monkeypatch.setitem(sys.modules, "pkg_resources", types.ModuleType("pkg_resources"))
-
-    with pytest.raises(ImportError):
-        pm.load_setuptools_entrypoints("qwe")
 
 
 def test_add_tracefuncs(he_pm):


### PR DESCRIPTION
This attempts to switch the backing metadata looking from `pkg_resources` (slow) to `importlib-metadata` (fast)

I had to expose one derived property on top of the `importlib_metadata` `Distribution` class to make it look like the `pkg_resources` one -- but otherwise this should be drop-in.

At least for pytest this isn't enough to get the full performance boost since `pytest` imports `pkg_resources` itself -- but baby steps!  I'll be following up with the pytest branch in https://github.com/pytest-dev/pytest/pull/5063