### PR TITLE
Convert hooks.varnames() to inspect.signature() on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
       env: TOXENV=pypy3-pytestrelease-coverage
     - python: '3.7'
       env: TOXENV=py37-pytestrelease-coverage
+    - python: '3.8-dev'
+      env: TOXENV=py38-pytestrelease-coverage
     - python: '2.7'
       env: TOXENV=py27-pytestmaster-coverage
     - python: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
 
 install:
   - pip install -U pip
-  - pip install -U setuptools tox
+  - pip install -U --force-reinstall setuptools tox
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ jobs:
           repo: pytest-dev/pluggy
 
 install:
-  - pip install -U setuptools pip
-  - pip install -U tox
+  - pip install -U pip
+  - pip install -U setuptools tox
 
 script:
   - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ install:
   - echo PyPy installed
   - pypy --version
 
-  - C:\Python35\python -m pip install tox
+  - C:\Python35\python -m pip install -U pip
+  - C:\Python35\python -m pip install -U setuptools tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - pypy --version
 
   - C:\Python35\python -m pip install -U pip
-  - C:\Python35\python -m pip install -U setuptools tox
+  - C:\Python35\python -m pip install -U --force-reinstall setuptools tox
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/changelog/209.trivial.rst
+++ b/changelog/209.trivial.rst
@@ -1,0 +1,4 @@
+Use ``inspect.signature()`` instead of ``inspect.getfullargspec()`` internally. The latter is emitting a deprecation warning in Python 3.8 and
+breaks test suites that turn warnings into errors.
+
+Because of this fix, ``pluggy`` now depends on the ``funcsigs`` package on Python 2.

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        install_requires='funcsigs;python_version<="2.7"',
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ] + [
-    ("Programming Language :: Python :: %s" % x) for x in "2 2.7 3 3.4 3.5 3.6".split()
+    ("Programming Language :: Python :: %s" % x)
+    for x in "2 2.7 3 3.4 3.5 3.6 3.7 3.8".split()
 ]
 
 with open("README.rst", "rb") as fd:

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -6,9 +6,9 @@ import sys
 import warnings
 from .callers import _legacymulticall, _multicall
 
-try:
+if sys.version_info[0] >= 3:
     from inspect import signature, Parameter
-except ImportError:
+else:
     from funcsigs import signature, Parameter
 
 

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -124,18 +124,6 @@ def normalize_hookimpl_opts(opts):
     opts.setdefault("optionalhook", False)
 
 
-if hasattr(inspect, "getfullargspec"):
-
-    def _getargspec(func):
-        return inspect.getfullargspec(func)
-
-
-else:
-
-    def _getargspec(func):
-        return inspect.getargspec(func)
-
-
 _PYPY3 = hasattr(sys, "pypy_version_info") and sys.version_info.major == 3
 
 
@@ -163,22 +151,41 @@ def varnames(func):
         except Exception:
             return ()
 
-    try:  # func MUST be a function or method here or we won't parse any args
-        spec = _getargspec(func)
-    except TypeError:
-        return (), ()
+    # func MUST be a function or method here or we won't parse any args
+    # this is what we return if it is not
+    non_function = (), ()
 
-    args, defaults = tuple(spec.args), spec.defaults
-    if defaults:
-        index = -len(defaults)
-        args, defaults = args[:index], tuple(args[index:])
+    if hasattr(inspect, "signature"):
+        try:
+            signature = inspect.signature(func)
+        except ValueError:
+            return non_function
+
+        empty = inspect.Parameter.empty
+        variable = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        parameters = signature.parameters.values()
+        parameters = tuple(p for p in parameters if p.kind not in variable)
+        args = tuple(p.name for p in parameters if p.default is empty)
+        defaults = tuple(p.name for p in parameters if p.default is not empty)
+        mangled_self = inspect.ismethod(func)
     else:
-        defaults = ()
+        try:
+            spec = inspect.getargspec(func)
+        except TypeError:
+            return non_function
+
+        args, defaults = tuple(spec.args), spec.defaults
+        if defaults:
+            index = -len(defaults)
+            args, defaults = args[:index], tuple(args[index:])
+        else:
+            defaults = ()
+        mangled_self = False
 
     # strip any implicit instance arg
     # pypy3 uses "obj" instead of "self" for default dunder methods
     implicit_names = ("self",) if not _PYPY3 else ("self", "obj")
-    if args:
+    if args and not mangled_self:
         if inspect.ismethod(func) or (
             "." in getattr(func, "__qualname__", ()) and args[0] in implicit_names
         ):


### PR DESCRIPTION
Avoids a possible deprecation warning with inspect.getfullargspec()

Fixes https://github.com/pytest-dev/pluggy/issues/209