### PR TITLE
Fix a regression with keyword only arguments

### DIFF
--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -178,9 +178,9 @@ def varnames(func):
         # func MUST be a function or method here or we won't parse any args
         return (), ()
 
-    variable = (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD)
+    positional = (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
     parameters = sig.parameters.values()
-    parameters = tuple(p for p in parameters if p.kind not in variable)
+    parameters = tuple(p for p in parameters if p.kind in positional)
     args = tuple(p.name for p in parameters if p.default is Parameter.empty)
     defaults = tuple(p.name for p in parameters if p.default is not Parameter.empty)
 

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -1,6 +1,9 @@
 from pluggy.hooks import varnames
 from pluggy.manager import _formatdef
 
+import sys
+import pytest
+
 
 def test_varnames():
     def f(x):
@@ -45,6 +48,24 @@ def test_varnames_class():
     assert varnames(D) == ((), ())
     assert varnames(E) == (("x",), ())
     assert varnames(F) == ((), ())
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3,), reason="Keyword only arguments are Python 3 only"
+)
+def test_varnames_keyword_only():
+    # SyntaxError on Python 2, so we exec
+    ns = {}
+    exec(
+        "def f1(x, *, y): pass\n"
+        "def f2(x, *, y=3): pass\n"
+        "def f3(x=1, *, y=3): pass\n",
+        ns,
+    )
+
+    assert varnames(ns["f1"]) == (("x",), ())
+    assert varnames(ns["f2"]) == (("x",), ())
+    assert varnames(ns["f3"]) == ((), ("x",))
 
 
 def test_formatdef():


### PR DESCRIPTION
Introduced in https://github.com/pytest-dev/pluggy/pull/210

Note: In "normal" Python, exec exports the defined names, however in pytest, I needed to use globals.