### PR TITLE
Revert varnames() refactor to use inspect.Signature

### DIFF
--- a/changelog/209.trivial.rst
+++ b/changelog/209.trivial.rst
@@ -1,4 +1,0 @@
-Use ``inspect.signature()`` instead of ``inspect.getfullargspec()`` internally. The latter is emitting a deprecation warning in Python 3.8 and
-breaks test suites that turn warnings into errors.
-
-Because of this fix, ``pluggy`` now depends on the ``funcsigs`` package on Python 2.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-        install_requires='funcsigs;python_version<="2.7"',
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pluggy/pull/212

This reverts commits:

* bebd02418f67d7a0f01ab27b9cfe7d0d7650faa9
* 39c6247294029447045f97d91d5a1a2af9be92ce
* 2008a3d5d164f745fb0d9550d3576dce6bf6c59f
* 68e56e553d69228e25ffab54d2bcc234433c3069
* 62f28acac8d1249e5b907c16256594b5a6697474
* ec28f027180961cdf86b21c8433d3b2f4c41af13

Closes #212