### PR TITLE
importlib-metadata again

### DIFF
--- a/changelog/215.feature.rst
+++ b/changelog/215.feature.rst
@@ -1,0 +1,1 @@
+Switch from ``pkg_resources`` to ``importlib-metadata`` for entrypoint detection for improved performance and import time.  This time with ``.egg`` support.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+import importlib_metadata
 
 
 extensions = [
@@ -20,14 +20,13 @@ master_doc = "index"
 
 # General information about the project.
 
-dist = pkg_resources.get_distribution("pluggy")
-project = dist.project_name
+project = "pluggy"
 copyright = u"2016, Holger Krekel"
 author = "Holger Krekel"
 
-release = dist.version
+release = importlib_metadata.version(project)
 # The short X.Y version.
-version = u".".join(dist.version.split(".")[:2])
+version = u".".join(release.split(".")[:2])
 
 
 language = None

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        install_requires=["importlib-metadata>=0.9"],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-        install_requires=["importlib-metadata>=0.9"],
+        install_requires=["importlib-metadata>=0.12"],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -281,10 +281,13 @@ class PluginManager(object):
         count = 0
         for dist in importlib_metadata.distributions():
             for ep in dist.entry_points:
-                if ep.group != group or (name is not None and ep.name != name):
-                    continue
-                # is the plugin registered or blocked?
-                if self.get_plugin(ep.name) or self.is_blocked(ep.name):
+                if (
+                    ep.group != group
+                    or (name is not None and ep.name != name)
+                    # already registered
+                    or self.get_plugin(ep.name)
+                    or self.is_blocked(ep.name)
+                ):
                     continue
                 plugin = ep.load()
                 self.register(plugin, name=ep.name)

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -3,6 +3,8 @@ from . import _tracing
 from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 import warnings
 
+import importlib_metadata
+
 
 def _warn_for_function(warning, function):
     warnings.warn_explicit(
@@ -23,6 +25,23 @@ class PluginValidationError(Exception):
     def __init__(self, plugin, message):
         self.plugin = plugin
         super(Exception, self).__init__(message)
+
+
+class DistFacade(object):
+    """Emulate a pkg_resources Distribution"""
+
+    def __init__(self, dist):
+        self._dist = dist
+
+    @property
+    def project_name(self):
+        return self.metadata["name"]
+
+    def __getattr__(self, attr, default=None):
+        return getattr(self._dist, attr, default)
+
+    def __dir__(self):
+        return sorted(dir(self._dist) + ["_dist", "project_name"])
 
 
 class PluginManager(object):
@@ -259,29 +278,18 @@ class PluginManager(object):
         :rtype: int
         :return: return the number of loaded plugins by this call.
         """
-        from pkg_resources import (
-            iter_entry_points,
-            DistributionNotFound,
-            VersionConflict,
-        )
-
         count = 0
-        for ep in iter_entry_points(group, name=name):
-            # is the plugin registered or blocked?
-            if self.get_plugin(ep.name) or self.is_blocked(ep.name):
-                continue
-            try:
+        for dist in importlib_metadata.distributions():
+            for ep in dist.entry_points:
+                if ep.group != group or (name is not None and ep.name != name):
+                    continue
+                # is the plugin registered or blocked?
+                if self.get_plugin(ep.name) or self.is_blocked(ep.name):
+                    continue
                 plugin = ep.load()
-            except DistributionNotFound:
-                continue
-            except VersionConflict as e:
-                raise PluginValidationError(
-                    plugin=None,
-                    message="Plugin %r could not be loaded: %s!" % (ep.name, e),
-                )
-            self.register(plugin, name=ep.name)
-            self._plugin_distinfo.append((plugin, ep.dist))
-            count += 1
+                self.register(plugin, name=ep.name)
+                self._plugin_distinfo.append((plugin, DistFacade(dist)))
+                count += 1
         return count
 
     def list_plugin_distinfo(self):

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -3,7 +3,7 @@
 """
 import pytest
 import types
-import sys
+import importlib_metadata
 from pluggy import (
     PluginManager,
     PluginValidationError,
@@ -447,62 +447,38 @@ def example_hook():
 
 
 def test_load_setuptools_instantiation(monkeypatch, pm):
-    pkg_resources = pytest.importorskip("pkg_resources")
+    class EntryPoint(object):
+        name = "myname"
+        group = "hello"
+        value = "myname:foo"
 
-    def my_iter(group, name=None):
-        assert group == "hello"
+        def load(self):
+            class PseudoPlugin(object):
+                x = 42
 
-        class EntryPoint(object):
-            name = "myname"
-            dist = None
+            return PseudoPlugin()
 
-            def load(self):
-                class PseudoPlugin(object):
-                    x = 42
+    class Distribution(object):
+        entry_points = (EntryPoint(),)
 
-                return PseudoPlugin()
+    dist = Distribution()
 
-        return iter([EntryPoint()])
+    def my_distributions():
+        return (dist,)
 
-    monkeypatch.setattr(pkg_resources, "iter_entry_points", my_iter)
+    monkeypatch.setattr(importlib_metadata, "distributions", my_distributions)
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 1
     plugin = pm.get_plugin("myname")
     assert plugin.x == 42
-    assert pm.list_plugin_distinfo() == [(plugin, None)]
+    ret = pm.list_plugin_distinfo()
+    # poor man's `assert ret == [(plugin, mock.ANY)]`
+    assert len(ret) == 1
+    assert len(ret[0]) == 2
+    assert ret[0][0] == plugin
+    assert ret[0][1]._dist == dist
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 0  # no plugin loaded by this call
-
-
-def test_load_setuptools_version_conflict(monkeypatch, pm):
-    """Check that we properly handle a VersionConflict problem when loading entry points"""
-    pkg_resources = pytest.importorskip("pkg_resources")
-
-    def my_iter(group, name=None):
-        assert group == "hello"
-
-        class EntryPoint(object):
-            name = "myname"
-            dist = None
-
-            def load(self):
-                raise pkg_resources.VersionConflict("Some conflict")
-
-        return iter([EntryPoint()])
-
-    monkeypatch.setattr(pkg_resources, "iter_entry_points", my_iter)
-    with pytest.raises(
-        PluginValidationError,
-        match="Plugin 'myname' could not be loaded: Some conflict!",
-    ):
-        pm.load_setuptools_entrypoints("hello")
-
-
-def test_load_setuptools_not_installed(monkeypatch, pm):
-    monkeypatch.setitem(sys.modules, "pkg_resources", types.ModuleType("pkg_resources"))
-
-    with pytest.raises(ImportError):
-        pm.load_setuptools_entrypoints("qwe")
 
 
 def test_add_tracefuncs(he_pm):


### PR DESCRIPTION
I've fixed the `.egg` problem upstream, so we can try this again!

Originally introduced in #199, reverted in #206 to fix #205.

I validated that the fix works by doing the following:

1. First I created an egg of pluggy by running this: `python setup.py bdist_egg`
2. Next I created a small project which uses `pytest-runner`:

    ```python
    # setup.py
    from setuptools import setup

    setup(
        name='wat',
        setup_requires=["pytest-runner"],
        tests_require=["pytest"],
    )
    ```

    ```python
    # tests/foo_test.py
    def test(): pass
    ```
3. Then I seeded my egg into the directory which setuptools installs into

    ```bash
    mkdir .eggs
    cp ../dist/*.egg .eggs/
    ```

4. then I ran `python setup.py pytest` -- I made sure it didn't download a new egg for pluggy, here's the output of that


```
$ python setup.py pytest
running pytest
Searching for pytest
Reading https://pypi.org/simple/pytest/
...

Installed /home/asottile/workspace/pluggy/x/.eggs/py-1.8.0-py3.6.egg
Searching for pluggy!=0.10,<1.0,>=0.9
Best match: pluggy 0.11.1.dev21+g18cab33
Processing pluggy-0.11.1.dev21+g18cab33-py3.6.egg

Using /home/asottile/workspace/pluggy/x/.eggs/pluggy-0.11.1.dev21+g18cab33-py3.6.egg

...

Installed /home/asottile/workspace/pluggy/x/.eggs/importlib_metadata-0.15-py3.6.egg

...

============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.5.0, py-1.8.0, pluggy-0.11.1.dev21+g18cab33
rootdir: /home/asottile/workspace/pluggy, inifile: tox.ini
collected 1 item                                                               

tests/foo_test.py .                                                      [100%]

=========================== 1 passed in 0.04 seconds ===========================
```