### PR TITLE
Replace importlib_metadata with importlib.metadata on Python 3.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,16 @@ jobs:
       env: TOXENV=py37-pytestrelease-coverage
     - python: '3.8-dev'
       env: TOXENV=py38-pytestrelease-coverage
-    - python: '2.7'
-      env: TOXENV=py27-pytestmaster-coverage
-    - python: '2.7'
-      env: TOXENV=py27-pytestfeatures-coverage
     - python: '3.6'
       env: TOXENV=py36-pytestmaster-coverage
     - python: '3.6'
       env: TOXENV=py36-pytestfeatures-coverage
     - python: '3.6'
       env: TOXENV=benchmark
+    - python: '3.7'
+      env: TOXENV=py37-pytestmaster-coverage
+    - python: '3.7'
+      env: TOXENV=py37-pytestfeatures-coverage
 
     - stage: deploy
       python: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,8 @@ environment:
   - TOXENV: "py34-pytestrelease"
   - TOXENV: "py35-pytestrelease"
   - TOXENV: "py36-pytestrelease"
+  - TOXENV: "py37-pytestrelease"
   - TOXENV: "pypy-pytestrelease"
-  - TOXENV: "py27-pytestmaster"
-  - TOXENV: "py27-pytestfeatures"
   - TOXENV: "py36-pytestmaster"
   - TOXENV: "py36-pytestfeatures"
 

--- a/changelog/222.trivial.rst
+++ b/changelog/222.trivial.rst
@@ -1,0 +1,2 @@
+Replace ``importlib_metadata`` backport with ``importlib.metadata`` from the
+standard library on Python 3.8+.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-import importlib_metadata
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 extensions = [
@@ -24,7 +29,7 @@ project = "pluggy"
 copyright = u"2016, Holger Krekel"
 author = "Holger Krekel"
 
-release = importlib_metadata.version(project)
+release = metadata.version(project)
 # The short X.Y version.
 version = u".".join(release.split(".")[:2])
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-        install_requires=["importlib-metadata>=0.12"],
+        install_requires=['importlib-metadata>=0.12;python_version<"3.8"'],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -1,9 +1,13 @@
 import inspect
+import sys
 from . import _tracing
 from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 import warnings
 
-import importlib_metadata
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 def _warn_for_function(warning, function):
@@ -279,7 +283,7 @@ class PluginManager(object):
         :return: return the number of loaded plugins by this call.
         """
         count = 0
-        for dist in importlib_metadata.distributions():
+        for dist in metadata.distributions():
             for ep in dist.entry_points:
                 if (
                     ep.group != group

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -2,8 +2,9 @@
 ``PluginManager`` unit and public API testing.
 """
 import pytest
+import sys
 import types
-import importlib_metadata
+
 from pluggy import (
     PluginManager,
     PluginValidationError,
@@ -11,6 +12,11 @@ from pluggy import (
     HookimplMarker,
     HookspecMarker,
 )
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 
 hookspec = HookspecMarker("example")
@@ -466,7 +472,7 @@ def test_load_setuptools_instantiation(monkeypatch, pm):
     def my_distributions():
         return (dist,)
 
-    monkeypatch.setattr(importlib_metadata, "distributions", my_distributions)
+    monkeypatch.setattr(metadata, "distributions", my_distributions)
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 1
     plugin = pm.get_plugin("myname")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=linting,docs,py{27,34,35,36,py,py3}-pytestrelease,py{27,36}-pytest{master,features}
+envlist=linting,docs,py{27,34,35,36,37,38,py,py3}-pytestrelease,py{36,37}-pytest{master,features}
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 minversion=2.0
 testpaths = testing
 #--pyargs --doctest-modules --ignore=.tox
-addopts=-ra
+addopts=-r a
 filterwarnings =
   error
 


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pluggy/issues/222

Got `pytest: error: unrecognized arguments: -ra` with tox on 3.8 :(