### PR TITLE
Add type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.mypy_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: flake8
+        additional_dependencies: [flake8-typing-imports]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.720
+    hooks:
+    -   id: mypy
+        files: ^(src/|testing/)
+        args: []
 -   repo: local
     hooks:
     -   id: rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -777,7 +777,9 @@ using the :py:meth:`pluggy._HookCaller.call_historic()` method:
 
 
     # call with history; no results returned
-    pm.hook.myhook.call_historic(config=config, args=sys.argv, result_callback=callback)
+    pm.hook.myhook.call_historic(
+        kwargs={"config": config, "args": sys.argv}, result_callback=callback
+    )
 
     # ... more of our program ...
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,20 @@ license_file=LICENSE
 
 [devpi:upload]
 formats=sdist.tgz,bdist_wheel
+
+[mypy]
+check_untyped_defs = True
+ignore_missing_imports = True
+no_implicit_optional = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True
+[mypy-pluggy.*]
+disallow_any_decorated = True
+disallow_any_generics = True
+disallow_any_unimported = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -3,17 +3,39 @@ Tracing utils
 """
 from .callers import _Result
 
+if False:  # TYPE_CHECKING
+    from typing import Any
+    from typing import Callable
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Sequence
+    from typing import Tuple
+    from typing import Union
+
+    from .hooks import HookImpl
+    from .hooks import _HookCaller
+    from .manager import PluginManager
+
+    _Writer = Callable[[str], None]
+    _Processor = Callable[[Tuple[str, ...], Sequence[object]], None]
+    _BeforeTrace = Callable[[str, List[HookImpl], Dict[str, Any]], None]
+    _AfterTrace = Callable[[_Result[Any], str, List[HookImpl], Dict[str, Any]], None]
+
 
 class TagTracer(object):
     def __init__(self):
-        self._tag2proc = {}
-        self.writer = None
+        # type: () -> None
+        self._tag2proc = {}  # type: Dict[Tuple[str, ...], _Processor]
+        self.writer = None  # type: Optional[_Writer]
         self.indent = 0
 
     def get(self, name):
+        # type: (str) -> TagTracerSub
         return TagTracerSub(self, (name,))
 
     def format_message(self, tags, args):
+        # type: (Sequence[str], Sequence[object]) -> List[str]
         if isinstance(args[-1], dict):
             extra = args[-1]
             args = args[:-1]
@@ -30,6 +52,7 @@ class TagTracer(object):
         return lines
 
     def processmessage(self, tags, args):
+        # type: (Tuple[str, ...], Sequence[object]) -> None
         if self.writer is not None and args:
             lines = self.format_message(tags, args)
             self.writer("".join(lines))
@@ -39,9 +62,11 @@ class TagTracer(object):
             pass
 
     def setwriter(self, writer):
+        # type: (_Writer) -> None
         self.writer = writer
 
     def setprocessor(self, tags, processor):
+        # type: (Union[str, Tuple[str, ...]], _Processor) -> None
         if isinstance(tags, str):
             tags = tuple(tags.split(":"))
         else:
@@ -51,21 +76,26 @@ class TagTracer(object):
 
 class TagTracerSub(object):
     def __init__(self, root, tags):
+        # type: (TagTracer, Tuple[str, ...]) -> None
         self.root = root
         self.tags = tags
 
     def __call__(self, *args):
+        # type: (object) -> None
         self.root.processmessage(self.tags, args)
 
     def setmyprocessor(self, processor):
+        # type: (_Processor) -> None
         self.root.setprocessor(self.tags, processor)
 
     def get(self, name):
+        # type: (str) -> TagTracerSub
         return self.__class__(self.root, self.tags + (name,))
 
 
 class _TracedHookExecution(object):
     def __init__(self, pluginmanager, before, after):
+        # type: (PluginManager, _BeforeTrace, _AfterTrace) -> None
         self.pluginmanager = pluginmanager
         self.before = before
         self.after = after
@@ -73,11 +103,13 @@ class _TracedHookExecution(object):
         assert not isinstance(self.oldcall, _TracedHookExecution)
         self.pluginmanager._inner_hookexec = self
 
-    def __call__(self, hook, hook_impls, kwargs):
-        self.before(hook.name, hook_impls, kwargs)
-        outcome = _Result.from_call(lambda: self.oldcall(hook, hook_impls, kwargs))
-        self.after(outcome, hook.name, hook_impls, kwargs)
+    def __call__(self, hook, methods, kwargs):
+        # type: (_HookCaller, List[HookImpl], Dict[str, object]) -> Union[object, List[object]]
+        self.before(hook.name, methods, kwargs)
+        outcome = _Result.from_call(lambda: self.oldcall(hook, methods, kwargs))
+        self.after(outcome, hook.name, methods, kwargs)
         return outcome.get_result()
 
     def undo(self):
+        # type: () -> None
         self.pluginmanager._inner_hookexec = self.oldcall

--- a/src/pluggy/callers.py
+++ b/src/pluggy/callers.py
@@ -15,8 +15,51 @@ def _reraise(cls, val, tb):
 """
     )
 
+if False:  # TYPE_CHECKING
+    from types import TracebackType
+    from typing import Callable
+    from typing import cast
+    from typing import Dict
+    from typing import Generator
+    from typing import Generic
+    from typing import List
+    from typing import NoReturn
+    from typing import Optional
+    from typing import Tuple
+    from typing import Type
+    from typing import TypeVar
+    from typing import Union
+
+    from .hooks import HookImpl
+
+    _T = TypeVar("_T")
+
+    _ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
+
+    _WrapController = Generator[None, "_Result[_T]", None]
+    _HookImplFunction = Callable[..., Union[_T, _WrapController[_T]]]
+
+    def _reraise(cls, val, tb):
+        # type: (Type[BaseException], BaseException, TracebackType) -> NoReturn
+        pass
+
+
+else:
+
+    def cast(x, y):  # type: ignore
+        return y
+
+    _T = object()  # type: ignore
+
+    class _GenericMeta:
+        def __getitem__(self, parameter):  # type: ignore
+            return object
+
+    Generic = _GenericMeta()  # type: ignore
+
 
 def _raise_wrapfail(wrap_controller, msg):
+    # type: (_WrapController[_T], str) -> NoReturn
     co = wrap_controller.gi_code
     raise RuntimeError(
         "wrap_controller at %r %s:%d %s"
@@ -28,17 +71,20 @@ class HookCallError(Exception):
     """ Hook was called wrongly. """
 
 
-class _Result(object):
+class _Result(Generic[_T]):
     def __init__(self, result, excinfo):
+        # type: (Optional[_T], Optional[_ExcInfo]) -> None
         self._result = result
         self._excinfo = excinfo
 
     @property
     def excinfo(self):
+        # type: () -> Optional[_ExcInfo]
         return self._excinfo
 
     @property
     def result(self):
+        # type: () -> Optional[_T]
         """Get the result(s) for this hook call (DEPRECATED in favor of ``get_result()``)."""
         msg = "Use get_result() which forces correct exception handling"
         warnings.warn(DeprecationWarning(msg), stacklevel=2)
@@ -46,16 +92,22 @@ class _Result(object):
 
     @classmethod
     def from_call(cls, func):
+        # type: (Callable[[], _T]) -> _Result[_T]
         __tracebackhide__ = True
         result = excinfo = None
         try:
             result = func()
         except BaseException:
-            excinfo = sys.exc_info()
+            _excinfo = sys.exc_info()
+            assert _excinfo[0] is not None
+            assert _excinfo[1] is not None
+            assert _excinfo[2] is not None
+            excinfo = (_excinfo[0], _excinfo[1], _excinfo[2])
 
         return cls(result, excinfo)
 
     def force_result(self, result):
+        # type: (_T) -> None
         """Force the result(s) to ``result``.
 
         If the hook was marked as a ``firstresult`` a single value should
@@ -66,6 +118,7 @@ class _Result(object):
         self._excinfo = None
 
     def get_result(self):
+        # type: () -> _T
         """Get the result(s) for this hook call.
 
         If the hook was marked as a ``firstresult`` only a single value
@@ -73,7 +126,7 @@ class _Result(object):
         """
         __tracebackhide__ = True
         if self._excinfo is None:
-            return self._result
+            return self._result  # type: ignore
         else:
             ex = self._excinfo
             if _py3:
@@ -82,6 +135,7 @@ class _Result(object):
 
 
 def _wrapped_call(wrap_controller, func):
+    # type: (_WrapController[_T], Callable[[], _T]) -> _T
     """ Wrap calling to a function with a generator which needs to yield
     exactly once.  The yield point will trigger calling the wrapped function
     and return its ``_Result`` to the yield point.  The generator then needs
@@ -110,14 +164,17 @@ class _LegacyMultiCall(object):
     # in execute() and simplify/speed up the execute loop.
 
     def __init__(self, hook_impls, kwargs, firstresult=False):
+        # type: (List[HookImpl], Dict[str, object], bool) -> None
         self.hook_impls = hook_impls
         self.caller_kwargs = kwargs  # come from _HookCaller.__call__()
         self.caller_kwargs["__multicall__"] = self
         self.firstresult = firstresult
 
     def execute(self):
+        # type: () -> Union[object, Optional[List[object]]]
         caller_kwargs = self.caller_kwargs
-        self.results = results = []
+        results = []  # type: List[object]
+        self.results = results
         firstresult = self.firstresult
 
         while self.hook_impls:
@@ -130,9 +187,12 @@ class _LegacyMultiCall(object):
                         raise HookCallError(
                             "hook call must provide argument %r" % (argname,)
                         )
-            if hook_impl.hookwrapper:
-                return _wrapped_call(hook_impl.function(*args), self.execute)
             res = hook_impl.function(*args)
+            if hook_impl.hookwrapper:
+                # If this cast is not valid, a type error is raised below,
+                # which is the desired response.
+                gen = cast("_WrapController[object]", res)
+                return _wrapped_call(gen, self.execute)
             if res is not None:
                 if firstresult:
                     return res
@@ -141,7 +201,10 @@ class _LegacyMultiCall(object):
         if not firstresult:
             return results
 
+        return None
+
     def __repr__(self):
+        # type: () -> str
         status = "%d meths" % (len(self.hook_impls),)
         if hasattr(self, "results"):
             status = ("%d results, " % len(self.results)) + status
@@ -149,19 +212,21 @@ class _LegacyMultiCall(object):
 
 
 def _legacymulticall(hook_impls, caller_kwargs, firstresult=False):
+    # type: (List[HookImpl], Dict[str, object], bool) -> Union[object, Optional[List[object]]]
     return _LegacyMultiCall(
         hook_impls, caller_kwargs, firstresult=firstresult
     ).execute()
 
 
 def _multicall(hook_impls, caller_kwargs, firstresult=False):
+    # type: (List[HookImpl], Dict[str, object], bool) -> Union[object, List[object]]
     """Execute a call into multiple python functions/methods and return the
     result(s).
 
     ``caller_kwargs`` comes from _HookCaller.__call__().
     """
     __tracebackhide__ = True
-    results = []
+    results = []  # type: List[object]
     excinfo = None
     try:  # run impl and wrapper setup functions in a loop
         teardowns = []
@@ -176,24 +241,32 @@ def _multicall(hook_impls, caller_kwargs, firstresult=False):
                                 "hook call must provide argument %r" % (argname,)
                             )
 
+                res = hook_impl.function(*args)
                 if hook_impl.hookwrapper:
+                    # If this cast is not valid, a type error is raised below,
+                    # which is the desired response.
+                    gen = cast("_WrapController[object]", res)
                     try:
-                        gen = hook_impl.function(*args)
                         next(gen)  # first yield
                         teardowns.append(gen)
                     except StopIteration:
                         _raise_wrapfail(gen, "did not yield")
                 else:
-                    res = hook_impl.function(*args)
                     if res is not None:
                         results.append(res)
                         if firstresult:  # halt further impl calls
                             break
         except BaseException:
-            excinfo = sys.exc_info()
+            _excinfo = sys.exc_info()
+            assert _excinfo[0] is not None
+            assert _excinfo[1] is not None
+            assert _excinfo[2] is not None
+            excinfo = (_excinfo[0], _excinfo[1], _excinfo[2])
     finally:
         if firstresult:  # first result hooks return a single value
-            outcome = _Result(results[0] if results else None, excinfo)
+            outcome = _Result(
+                results[0] if results else None, excinfo
+            )  # type: _Result[Union[object, List[object]]]
         else:
             outcome = _Result(results, excinfo)
 

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -6,6 +6,60 @@ import sys
 import warnings
 from .callers import _legacymulticall, _multicall
 
+if False:  # TYPE_CHECKING
+    from types import ModuleType
+    from typing import Any
+    from typing import Callable
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Sequence
+    from typing import Tuple
+    from typing import TypeVar
+    from typing import Union
+    from typing import overload
+    from typing_extensions import TypedDict
+
+    from .callers import _HookImplFunction
+    from .manager import _Plugin
+    from ._tracing import TagTracerSub
+
+    _F = TypeVar("_F", bound=Callable[..., object])
+    _Namespace = Union[ModuleType, type]
+    _HookSpecOpts = TypedDict(
+        "_HookSpecOpts",
+        {"firstresult": bool, "historic": bool, "warn_on_impl": Optional[Warning]},
+    )
+    _HookImplOpts = TypedDict(
+        "_HookImplOpts",
+        {"hookwrapper": bool, "optionalhook": bool, "tryfirst": bool, "trylast": bool},
+    )
+    _HookExec = Callable[
+        ["_HookCaller", List["HookImpl"], Dict[str, object]],
+        Union[object, List[object]],
+    ]
+
+    class _RelayType(object):
+        def __getattr__(self, name):
+            # type: (str) -> _HookCaller
+            pass
+
+
+else:
+
+    def _overload_dummy(*args, **kwds):  # type: ignore
+        raise NotImplementedError(
+            "You should not call an overloaded function. "
+            "A series of @overload-decorated functions "
+            "outside a stub module should always be followed "
+            "by an implementation that is not @overload-ed."
+        )
+
+    def overload(func):  # type: ignore
+        return _overload_dummy
+
+    _RelayType = object  # type: ignore
+
 
 class HookspecMarker(object):
     """ Decorator helper class for marking functions as hook specifications.
@@ -16,11 +70,39 @@ class HookspecMarker(object):
     """
 
     def __init__(self, project_name):
+        # type: (str) -> None
         self.project_name = project_name
 
+    @overload
     def __call__(
-        self, function=None, firstresult=False, historic=False, warn_on_impl=None
+        self,
+        function,  # type: _F
+        firstresult=False,  # type: bool
+        historic=False,  # type: bool
+        warn_on_impl=None,  # type: Optional[Warning]
     ):
+        # type: (...) -> _F
+        pass
+
+    @overload  # noqa: F811
+    def __call__(
+        self,
+        function=None,  # type: None
+        firstresult=False,  # type: bool
+        historic=False,  # type: bool
+        warn_on_impl=None,  # type: Optional[Warning]
+    ):
+        # type: (...) -> Callable[[_F], _F]
+        pass
+
+    def __call__(  # noqa: F811
+        self,
+        function=None,  # type: Optional[_F]
+        firstresult=False,  # type: bool
+        historic=False,  # type: bool
+        warn_on_impl=None,  # type: Optional[Warning]
+    ):
+        # type: (...) -> Union[_F, Callable[[_F], _F]]
         """ if passed a function, directly sets attributes on the function
         which will make it discoverable to add_hookspecs().  If passed no
         function, returns a decorator which can be applied to a function
@@ -36,17 +118,15 @@ class HookspecMarker(object):
         """
 
         def setattr_hookspec_opts(func):
+            # type: (_F) -> _F
             if historic and firstresult:
                 raise ValueError("cannot have a historic firstresult hook")
-            setattr(
-                func,
-                self.project_name + "_spec",
-                dict(
-                    firstresult=firstresult,
-                    historic=historic,
-                    warn_on_impl=warn_on_impl,
-                ),
-            )
+            opts = {
+                "firstresult": firstresult,
+                "historic": historic,
+                "warn_on_impl": warn_on_impl,
+            }  # type: _HookSpecOpts
+            setattr(func, self.project_name + "_spec", opts)
             return func
 
         if function is not None:
@@ -64,17 +144,42 @@ class HookimplMarker(object):
     """
 
     def __init__(self, project_name):
+        # type: (str) -> None
         self.project_name = project_name
 
+    @overload
     def __call__(
         self,
-        function=None,
-        hookwrapper=False,
-        optionalhook=False,
-        tryfirst=False,
-        trylast=False,
+        function,  # type: _F
+        hookwrapper=False,  # type: bool
+        optionalhook=False,  # type: bool
+        tryfirst=False,  # type: bool
+        trylast=False,  # type: bool
     ):
+        # type: (...) -> _F
+        pass
 
+    @overload  # noqa: F811
+    def __call__(
+        self,
+        function=None,  # type: None
+        hookwrapper=False,  # type: bool
+        optionalhook=False,  # type: bool
+        tryfirst=False,  # type: bool
+        trylast=False,  # type: bool
+    ):
+        # type: (...) -> Callable[[_F], _F]
+        pass
+
+    def __call__(  # noqa: F811
+        self,
+        function=None,  # type: Optional[_F]
+        hookwrapper=False,  # type: bool
+        optionalhook=False,  # type: bool
+        tryfirst=False,  # type: bool
+        trylast=False,  # type: bool
+    ):
+        # type: (...) -> Union[_F, Callable[[_F], _F]]
         """ if passed a function, directly sets attributes on the function
         which will make it discoverable to register().  If passed no function,
         returns a decorator which can be applied to a function later using
@@ -99,16 +204,14 @@ class HookimplMarker(object):
         """
 
         def setattr_hookimpl_opts(func):
-            setattr(
-                func,
-                self.project_name + "_impl",
-                dict(
-                    hookwrapper=hookwrapper,
-                    optionalhook=optionalhook,
-                    tryfirst=tryfirst,
-                    trylast=trylast,
-                ),
-            )
+            # type: (_F) -> _F
+            opts = {
+                "hookwrapper": hookwrapper,
+                "optionalhook": optionalhook,
+                "tryfirst": tryfirst,
+                "trylast": trylast,
+            }  # type: _HookImplOpts
+            setattr(func, self.project_name + "_impl", opts)
             return func
 
         if function is None:
@@ -118,43 +221,34 @@ class HookimplMarker(object):
 
 
 def normalize_hookimpl_opts(opts):
+    # type: (Dict[str, Any]) -> None
     opts.setdefault("tryfirst", False)
     opts.setdefault("trylast", False)
     opts.setdefault("hookwrapper", False)
     opts.setdefault("optionalhook", False)
 
 
-if hasattr(inspect, "getfullargspec"):
-
-    def _getargspec(func):
-        return inspect.getfullargspec(func)
-
-
-else:
-
-    def _getargspec(func):
-        return inspect.getargspec(func)
-
-
 _PYPY3 = hasattr(sys, "pypy_version_info") and sys.version_info.major == 3
 
 
 def varnames(func):
+    # type: (object) -> Tuple[Tuple[str, ...], Tuple[str, ...]]
     """Return tuple of positional and keywrord argument names for a function,
     method, class or callable.
 
     In case of a class, its ``__init__`` method is considered.
     For methods the ``self`` parameter is not included.
     """
-    cache = getattr(func, "__dict__", {})
+    dummy_cache = {}  # type: Dict[str, object]
+    cache = getattr(func, "__dict__", dummy_cache)  # type: Dict[str, object]
     try:
-        return cache["_varnames"]
+        return cache["_varnames"]  # type: ignore
     except KeyError:
         pass
 
     if inspect.isclass(func):
         try:
-            func = func.__init__
+            func = func.__init__  # type: ignore
         except AttributeError:
             return (), ()
     elif not inspect.isroutine(func):  # callable object?
@@ -164,7 +258,12 @@ def varnames(func):
             return (), ()
 
     try:  # func MUST be a function or method here or we won't parse any args
-        spec = _getargspec(func)
+        if hasattr(inspect, "getfullargspec"):
+            spec = inspect.getfullargspec(
+                func
+            )  # type: Union[inspect.FullArgSpec, inspect.ArgSpec]
+        else:
+            spec = inspect.getargspec(func)
     except TypeError:
         return (), ()
 
@@ -177,11 +276,13 @@ def varnames(func):
 
     # strip any implicit instance arg
     # pypy3 uses "obj" instead of "self" for default dunder methods
-    implicit_names = ("self",) if not _PYPY3 else ("self", "obj")
+    if not _PYPY3:
+        implicit_names = ("self",)  # type: Tuple[str, ...]
+    else:
+        implicit_names = ("self", "obj")
     if args:
-        if inspect.ismethod(func) or (
-            "." in getattr(func, "__qualname__", ()) and args[0] in implicit_names
-        ):
+        qualname = getattr(func, "__qualname__", "")  # type: str
+        if inspect.ismethod(func) or ("." in qualname and args[0] in implicit_names):
             args = args[1:]
 
     try:
@@ -191,58 +292,76 @@ def varnames(func):
     return args, kwargs
 
 
-class _HookRelay(object):
+class _HookRelay(_RelayType):
     """ hook holder object for performing 1:N hook calls where N is the number
     of registered plugins.
 
     """
 
     def __init__(self, trace):
+        # type: (TagTracerSub) -> None
         self._trace = trace
 
 
 class _HookCaller(object):
-    def __init__(self, name, hook_execute, specmodule_or_class=None, spec_opts=None):
+    def __init__(
+        self,
+        name,  # type: str
+        hook_execute,  # type: _HookExec
+        specmodule_or_class=None,  # type: Optional[_Namespace]
+        spec_opts=None,  # type: Optional[_HookSpecOpts]
+    ):
+        # type: (...) -> None
         self.name = name
-        self._wrappers = []
-        self._nonwrappers = []
+        self._wrappers = []  # type: List[HookImpl]
+        self._nonwrappers = []  # type: List[HookImpl]
         self._hookexec = hook_execute
         self.argnames = None
         self.kwargnames = None
         self.multicall = _multicall
-        self.spec = None
+        self.spec = None  # type: Optional[HookSpec]
         if specmodule_or_class is not None:
             assert spec_opts is not None
             self.set_specification(specmodule_or_class, spec_opts)
 
     def has_spec(self):
+        # type: () -> bool
         return self.spec is not None
 
     def set_specification(self, specmodule_or_class, spec_opts):
+        # type: (_Namespace, _HookSpecOpts) -> None
         assert not self.has_spec()
         self.spec = HookSpec(specmodule_or_class, self.name, spec_opts)
         if spec_opts.get("historic"):
-            self._call_history = []
+            self._call_history = (
+                []
+            )  # type: List[Tuple[Dict[str, object], Optional[Callable[[Any], None]]]]
 
     def is_historic(self):
+        # type: () -> bool
         return hasattr(self, "_call_history")
 
     def _remove_plugin(self, plugin):
+        # type: (_Plugin) -> None
         def remove(wrappers):
+            # type: (List[HookImpl]) -> Optional[bool]
             for i, method in enumerate(wrappers):
                 if method.plugin == plugin:
                     del wrappers[i]
                     return True
+            return None
 
         if remove(self._wrappers) is None:
             if remove(self._nonwrappers) is None:
                 raise ValueError("plugin %r not found" % (plugin,))
 
     def get_hookimpls(self):
+        # type: () -> List[HookImpl]
         # Order is important for _hookexec
         return self._nonwrappers + self._wrappers
 
     def _add_hookimpl(self, hookimpl):
+        # type: (HookImpl) -> None
         """Add an implementation to the callback chain.
         """
         if hookimpl.hookwrapper:
@@ -270,9 +389,11 @@ class _HookCaller(object):
             self.multicall = _legacymulticall
 
     def __repr__(self):
+        # type: () -> str
         return "<_HookCaller %r>" % (self.name,)
 
     def __call__(self, *args, **kwargs):
+        # type: (object, object) -> Any
         if args:
             raise TypeError("hook calling supports only keyword arguments")
         assert not self.is_historic()
@@ -288,7 +409,13 @@ class _HookCaller(object):
                 )
         return self._hookexec(self, self.get_hookimpls(), kwargs)
 
-    def call_historic(self, result_callback=None, kwargs=None, proc=None):
+    def call_historic(
+        self,
+        result_callback=None,  # type: Optional[Callable[[Any], None]]
+        kwargs=None,  # type: Optional[Dict[str, object]]
+        proc=None,  # type: Optional[Callable[[Any], None]]
+    ):
+        # type: (...) -> None
         """Call the hook with given ``kwargs`` for all registered plugins and
         for all plugins which will be registered afterwards.
 
@@ -308,19 +435,26 @@ class _HookCaller(object):
 
         self._call_history.append((kwargs or {}, result_callback))
         # historizing hooks don't return results
-        res = self._hookexec(self, self.get_hookimpls(), kwargs)
+        res = self._hookexec(self, self.get_hookimpls(), kwargs or {})
         if result_callback is None:
             return
         # XXX: remember firstresult isn't compat with historic
+        assert isinstance(res, list)
         for x in res or []:
             result_callback(x)
 
     def call_extra(self, methods, kwargs):
+        # type: (Sequence[Callable[..., object]], Dict[str, object]) -> Any
         """ Call the hook with some additional temporarily participating
         methods using the specified kwargs as call parameters. """
         old = list(self._nonwrappers), list(self._wrappers)
         for method in methods:
-            opts = dict(hookwrapper=False, trylast=False, tryfirst=False)
+            opts = {
+                "hookwrapper": False,
+                "optionalhook": False,
+                "trylast": False,
+                "tryfirst": False,
+            }  # type: _HookImplOpts
             hookimpl = HookImpl(None, "<temp>", method, opts)
             self._add_hookimpl(hookimpl)
         try:
@@ -329,34 +463,44 @@ class _HookCaller(object):
             self._nonwrappers, self._wrappers = old
 
     def _maybe_apply_history(self, method):
+        # type: (HookImpl) -> None
         """Apply call history to a new hookimpl if it is marked as historic.
         """
         if self.is_historic():
             for kwargs, result_callback in self._call_history:
                 res = self._hookexec(self, [method], kwargs)
                 if res and result_callback is not None:
+                    # XXX: remember firstresult isn't compat with historic
+                    assert isinstance(res, list)
                     result_callback(res[0])
 
 
 class HookImpl(object):
     def __init__(self, plugin, plugin_name, function, hook_impl_opts):
+        # type: (_Plugin, str, _HookImplFunction[object], _HookImplOpts) -> None
         self.function = function
         self.argnames, self.kwargnames = varnames(self.function)
         self.plugin = plugin
         self.opts = hook_impl_opts
         self.plugin_name = plugin_name
-        self.__dict__.update(hook_impl_opts)
+        self.hookwrapper = hook_impl_opts["hookwrapper"]
+        self.optionalhook = hook_impl_opts["optionalhook"]
+        self.tryfirst = hook_impl_opts["tryfirst"]
+        self.trylast = hook_impl_opts["trylast"]
 
     def __repr__(self):
+        # type: () -> str
         return "<HookImpl plugin_name=%r, plugin=%r>" % (self.plugin_name, self.plugin)
 
 
 class HookSpec(object):
     def __init__(self, namespace, name, opts):
+        # type: (_Namespace, str, _HookSpecOpts) -> None
         self.namespace = namespace
-        self.function = function = getattr(namespace, name)
+        function = getattr(namespace, name)  # type: Callable[..., object]
+        self.function = function
         self.name = name
-        self.argnames, self.kwargnames = varnames(function)
+        argnames, self.kwargnames = varnames(function)
         self.opts = opts
-        self.argnames = ["__multicall__"] + list(self.argnames)
+        self.argnames = ["__multicall__"] + list(argnames)
         self.warn_on_impl = opts.get("warn_on_impl")

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -171,9 +171,9 @@ def varnames(func):
     args, defaults = tuple(spec.args), spec.defaults
     if defaults:
         index = -len(defaults)
-        args, defaults = args[:index], tuple(args[index:])
+        args, kwargs = args[:index], tuple(args[index:])
     else:
-        defaults = ()
+        kwargs = ()
 
     # strip any implicit instance arg
     # pypy3 uses "obj" instead of "self" for default dunder methods
@@ -185,10 +185,10 @@ def varnames(func):
             args = args[1:]
 
     try:
-        cache["_varnames"] = args, defaults
+        cache["_varnames"] = args, kwargs
     except TypeError:
         pass
-    return args, defaults
+    return args, kwargs
 
 
 class _HookRelay(object):

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -161,7 +161,7 @@ def varnames(func):
         try:
             func = getattr(func, "__call__", func)
         except Exception:
-            return ()
+            return (), ()
 
     try:  # func MUST be a function or method here or we won't parse any args
         spec = _getargspec(func)

--- a/testing/test_deprecations.py
+++ b/testing/test_deprecations.py
@@ -28,6 +28,7 @@ def test_implprefix_deprecated():
 
 
 def test_callhistoric_proc_deprecated(pm):
+    # type: (PluginManager) -> None
     """``proc`` kwarg to `PluginMananger.call_historic()` is now officially
     deprecated.
     """
@@ -38,14 +39,15 @@ def test_callhistoric_proc_deprecated(pm):
         def m(self, x):
             pass
 
+    pm.add_hookspecs(P1)
     p1 = P1()
-    pm.add_hookspecs(p1)
     pm.register(p1)
     with pytest.deprecated_call():
-        pm.hook.m.call_historic(kwargs=dict(x=10), proc=lambda res: res)
+        pm.hook.m.call_historic(kwargs=dict(x=10), proc=lambda res: None)
 
 
 def test_multicall_deprecated(pm):
+    # type: (PluginManager) -> None
     class P1(object):
         @hookimpl
         def m(self, __multicall__, x):

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -81,7 +81,7 @@ def test_plugin_getattr_raises_errors():
         pass
 
     module = Module()
-    module.x = DontTouchMe()
+    module.x = DontTouchMe()  # type: ignore
 
     pm = PluginManager(hookspec.project_name)
     # register() would raise an error
@@ -106,7 +106,7 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
 
     pm = PluginManager(hookspec.project_name)
     pm.register(Plugin())
-    pm.add_hookspecs(Spec())
+    pm.add_hookspecs(Spec)
 
     with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
@@ -114,6 +114,7 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
         # calling should trigger a warning
         pm.hook.myhook(arg1=1)
 
+        assert warns is not None
         assert len(warns) == 1
         warning = warns[-1]
         assert issubclass(warning.category, Warning)
@@ -123,7 +124,7 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
 def test_repr():
     class Plugin:
         @hookimpl
-        def myhook():
+        def myhook():  # type: ignore
             raise NotImplementedError()
 
     pm = PluginManager(hookspec.project_name)

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -4,6 +4,9 @@ from pluggy.manager import _formatdef
 import sys
 import pytest
 
+if False:  # TYPE_CHECKING
+    from typing import Dict
+
 
 def test_varnames():
     def f(x):
@@ -55,7 +58,7 @@ def test_varnames_class():
 )
 def test_varnames_keyword_only():
     # SyntaxError on Python 2, so we exec
-    ns = {}
+    ns = {}  # type: Dict[str, object]
     exec(
         "def f1(x, *, y): pass\n"
         "def f2(x, *, y=3): pass\n"

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pluggy import HookimplMarker, HookspecMarker
+from pluggy import PluginManager, HookimplMarker, HookspecMarker
 from pluggy.hooks import HookImpl
 
 hookspec = HookspecMarker("example")
@@ -155,6 +155,7 @@ def test_adding_wrappers_ordering_tryfirst(hc, addmeth):
 
 
 def test_hookspec(pm):
+    # type: (PluginManager) -> None
     class HookSpec(object):
         @hookspec()
         def he_myhook1(arg1):
@@ -169,8 +170,11 @@ def test_hookspec(pm):
             pass
 
     pm.add_hookspecs(HookSpec)
+    assert pm.hook.he_myhook1.spec is not None
     assert not pm.hook.he_myhook1.spec.opts["firstresult"]
+    assert pm.hook.he_myhook2.spec is not None
     assert pm.hook.he_myhook2.spec.opts["firstresult"]
+    assert pm.hook.he_myhook3.spec is not None
     assert not pm.hook.he_myhook3.spec.opts["firstresult"]
 
 
@@ -188,6 +192,7 @@ def test_hookimpl(name, val):
 
 
 def test_hookrelay_registry(pm):
+    # type: (PluginManager) -> None
     """Verify hook caller instances are registered by name onto the relay
     and can be likewise unregistered."""
 

--- a/testing/test_invocations.py
+++ b/testing/test_invocations.py
@@ -1,5 +1,5 @@
 import pytest
-from pluggy import PluginValidationError, HookimplMarker, HookspecMarker
+from pluggy import PluginManager, PluginValidationError, HookimplMarker, HookspecMarker
 
 
 hookspec = HookspecMarker("example")
@@ -7,6 +7,7 @@ hookimpl = HookimplMarker("example")
 
 
 def test_argmismatch(pm):
+    # type: (PluginManager) -> None
     class Api(object):
         @hookspec
         def hello(self, arg):
@@ -26,6 +27,7 @@ def test_argmismatch(pm):
 
 
 def test_only_kwargs(pm):
+    # type: (PluginManager) -> None
     class Api(object):
         @hookspec
         def hello(self, arg):
@@ -40,6 +42,7 @@ def test_only_kwargs(pm):
 
 
 def test_opt_in_args(pm):
+    # type: (PluginManager) -> None
     """Verfiy that two hookimpls with mutex args can serve
     under the same spec.
     """
@@ -68,6 +71,7 @@ def test_opt_in_args(pm):
 
 
 def test_call_order(pm):
+    # type: (PluginManager) -> None
     class Api(object):
         @hookspec
         def hello(self, arg):
@@ -106,6 +110,7 @@ def test_call_order(pm):
 
 
 def test_firstresult_definition(pm):
+    # type: (PluginManager) -> None
     class Api(object):
         @hookspec(firstresult=True)
         def hello(self, arg):
@@ -144,6 +149,7 @@ def test_firstresult_definition(pm):
 
 
 def test_firstresult_force_result(pm):
+    # type: (PluginManager) -> None
     """Verify forcing a result in a wrapper.
     """
 
@@ -180,6 +186,7 @@ def test_firstresult_force_result(pm):
 
 
 def test_firstresult_returns_none(pm):
+    # type: (PluginManager) -> None
     """If None results are returned by underlying implementations ensure
     the multi-call loop returns a None value.
     """
@@ -202,6 +209,7 @@ def test_firstresult_returns_none(pm):
 
 
 def test_firstresult_no_plugin(pm):
+    # type: (PluginManager) -> None
     """If no implementations/plugins have been registered for a firstresult
     hook the multi-call loop should return a None value.
     """

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -1,20 +1,11 @@
 import pytest
 from pluggy import HookCallError, HookspecMarker, HookimplMarker
 from pluggy.hooks import HookImpl
-from pluggy.callers import _multicall, _legacymulticall, _LegacyMultiCall
+from pluggy.callers import _multicall, _legacymulticall
 
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
-
-
-def test_uses_copy_of_methods():
-    out = [lambda: 42]
-    mc = _LegacyMultiCall(out, {})
-    repr(mc)
-    out[:] = []
-    res = mc.execute()
-    return res == 42
 
 
 def MC(methods, kwargs, firstresult=False):

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -2,16 +2,21 @@ from pluggy._tracing import TagTracer
 
 import pytest
 
+if False:  # TYPE_CHECKING
+    from typing import List
+
 
 @pytest.fixture
 def rootlogger():
+    # type: () -> TagTracer
     return TagTracer()
 
 
 def test_simple(rootlogger):
+    # type: (TagTracer) -> None
     log = rootlogger.get("pytest")
     log("hello")
-    out = []
+    out = []  # type: List[str]
     rootlogger.setwriter(out.append)
     log("world")
     assert len(out) == 1
@@ -22,6 +27,7 @@ def test_simple(rootlogger):
 
 
 def test_indent(rootlogger):
+    # type: (TagTracer) -> None
     log = rootlogger.get("1")
     out = []
     log.root.setwriter(lambda arg: out.append(arg))
@@ -50,6 +56,7 @@ def test_indent(rootlogger):
 
 
 def test_readable_output_dictargs(rootlogger):
+    # type: (TagTracer) -> None
 
     out = rootlogger.format_message(["test"], [1])
     assert out == ["1 [test]\n"]
@@ -59,6 +66,7 @@ def test_readable_output_dictargs(rootlogger):
 
 
 def test_setprocessor(rootlogger):
+    # type: (TagTracer) -> None
     log = rootlogger.get("1")
     log2 = log.get("2")
     assert log2.tags == tuple("12")
@@ -79,6 +87,7 @@ def test_setprocessor(rootlogger):
 
 
 def test_setmyprocessor(rootlogger):
+    # type: (TagTracer) -> None
     log = rootlogger.get("1")
     log2 = log.get("2")
     out = []


### PR DESCRIPTION
Based on #224.

This PR adds type annotations to the library, using the Python 2-compatible syntax. The types are not exposed yet (a `py.typed` file is not distributed).

Motivation: while working on adding type annotations to pytest, I noticed that pluggy is a core part of its machinery and that having type annotations for it will be useful. However, the annotations here turn out to not be that useful, because the main interface, `plugin_manager.hook.*`, remains untyped (see #191). The API is very dynamic and doesn't lend itself easily to static annotations, though it might be possible, maybe with a mypy plugin. But the types are still useful for all of the regular non-dynamic API. They also help when trying to understand the code base - the type of each variable and how all of the types fit together. Finally, they help catch bugs when the code changes and add confidence when refactoring.

I tested it against pytest (feature branch): first that the test suite passes, and second that the type-checking passes (I manually added a `py.typed` file to pluggy in the venv to test that).

This PR is probably not that easy to review, adds some maintenance burden, and I also didn't discuss it first. If you don't feel type annotations are desirable for pluggy,, I'll understand :)