### PR TITLE
test_pluginmanager: use pluggy.manager.metadata

### DIFF
--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -5,9 +5,9 @@ from .hooks import HookImpl, _HookRelay, _HookCaller, normalize_hookimpl_opts
 import warnings
 
 if sys.version_info >= (3, 8):
-    from importlib import metadata
+    from importlib import metadata as importlib_metadata
 else:
-    import importlib_metadata as metadata
+    import importlib_metadata
 
 
 def _warn_for_function(warning, function):
@@ -283,7 +283,7 @@ class PluginManager(object):
         :return: return the number of loaded plugins by this call.
         """
         count = 0
-        for dist in metadata.distributions():
+        for dist in importlib_metadata.distributions():
             for ep in dist.entry_points:
                 if (
                     ep.group != group

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -2,7 +2,6 @@
 ``PluginManager`` unit and public API testing.
 """
 import pytest
-import sys
 import types
 
 from pluggy import (
@@ -12,11 +11,7 @@ from pluggy import (
     HookimplMarker,
     HookspecMarker,
 )
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
+from pluggy.manager import importlib_metadata
 
 
 hookspec = HookspecMarker("example")
@@ -472,7 +467,7 @@ def test_load_setuptools_instantiation(monkeypatch, pm):
     def my_distributions():
         return (dist,)
 
-    monkeypatch.setattr(metadata, "distributions", my_distributions)
+    monkeypatch.setattr(importlib_metadata, "distributions", my_distributions)
     num = pm.load_setuptools_entrypoints("hello")
     assert num == 1
     plugin = pm.get_plugin("myname")


### PR DESCRIPTION
This has the version switch in a central place only once.

Ref: https://github.com/pytest-dev/pluggy/pull/223/files#r315505111