### PR TITLE
Corrected install_requires syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def main():
         author_email="holger@merlinux.eu",
         url="https://github.com/pytest-dev/pluggy",
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-        install_requires=['importlib-metadata>=0.12;python_version<"3.8"'],
+        install_requires=["importlib-metadata>=0.12", "python_version<3.8"],
         extras_require={"dev": ["pre-commit", "tox"]},
         classifiers=classifiers,
         packages=["pluggy"],


### PR DESCRIPTION
When I run `sudo python3.5 setup.py install`, I get
> error in pluggy setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected ',' or end-of-list in importlib-metadata>=0.12;python_version<"3.8" at ;python_version<"3.8"

This PR fixes that by changing the syntax of the install_requires command. I don't see the original syntax suggested at https://packaging.python.org/discussions/install-requires-vs-requirements/. This PR uses the suggestion from https://stackoverflow.com/questions/8161617/how-can-i-specify-library-versions-in-setup-py