### PR TITLE
[RFC] multicall: hookwrapper: use yielded results, support firstresult=True

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,11 @@ source = pluggy/
   */lib/python*/site-packages/pluggy/
   */pypy*/site-packages/pluggy/
   *\Lib\site-packages\pluggy\
+
+[report]
+skip_covered = True
+show_missing = True
+exclude_lines =
+    \#\s*pragma: no cover
+    ^\s*raise NotImplementedError\b
+    ^\s*return NotImplemented\b

--- a/src/pluggy/callers.py
+++ b/src/pluggy/callers.py
@@ -179,8 +179,12 @@ def _multicall(hook_impls, caller_kwargs, firstresult=False):
                 if hook_impl.hookwrapper:
                     try:
                         gen = hook_impl.function(*args)
-                        next(gen)  # first yield
+                        res = next(gen)  # first yield
                         teardowns.append(gen)
+                        if res is not None:
+                            results.append(res)
+                            if firstresult:
+                                break
                     except StopIteration:
                         _raise_wrapfail(gen, "did not yield")
                 else:

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -142,7 +142,7 @@ def test_hookwrapper_order():
         out.append("m2 finish")
 
     res = MC([m2, m1], {})
-    assert res == []
+    assert res == [1, 2]
     assert out == ["m1 init", "m2 init", "m2 finish", "m1 finish"]
 
 
@@ -183,4 +183,27 @@ def test_hookwrapper_exception(exc):
 
     with pytest.raises(exc):
         MC([m2, m1], {})
+    assert out == ["m1 init", "m1 finish"]
+
+
+def test_hookwrapper_result():
+    out = []
+
+    @hookimpl(hookwrapper=True)
+    def m1():
+        out.append("m1 init")
+        yield "hookwrapper_result"
+        out.append("m1 finish")
+
+    @hookimpl
+    def m2():
+        out.append("m2")
+        return 2
+
+    res = MC([m2, m1], {})
+    assert res == ["hookwrapper_result", 2]
+    assert out == ["m1 init", "m2", "m1 finish"]
+    out[:] = []
+    res = MC([m2, m1], {}, firstresult=True)
+    assert res == "hookwrapper_result"
     assert out == ["m1 init", "m1 finish"]

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -197,8 +197,7 @@ def test_hookwrapper_firstresult():
 
     @hookimpl
     def m2():
-        out.append("m2")
-        return 2
+        raise NotImplementedError()
 
     res = MC([m2, m1], {}, firstresult=True)
     assert res == "hookwrapper_result"

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -186,7 +186,7 @@ def test_hookwrapper_exception(exc):
     assert out == ["m1 init", "m1 finish"]
 
 
-def test_hookwrapper_result():
+def test_hookwrapper_firstresult():
     out = []
 
     @hookimpl(hookwrapper=True)
@@ -200,10 +200,6 @@ def test_hookwrapper_result():
         out.append("m2")
         return 2
 
-    res = MC([m2, m1], {})
-    assert res == ["hookwrapper_result", 2]
-    assert out == ["m1 init", "m2", "m1 finish"]
-    out[:] = []
     res = MC([m2, m1], {}, firstresult=True)
     assert res == "hookwrapper_result"
     assert out == ["m1 init", "m1 finish"]


### PR DESCRIPTION
Ref: https://github.com/pytest-dev/pytest/issues/5301#issuecomment-573363212

Currently results from a hookwrapper are ignored, this changes the behavior (see `test_hookwrapper_order`).
Should this be explicitly enabled, e.g. via a new "use_hookwrapper_result" kwarg for the hookwrapper?  As the existing test shows "yield" might be used with a result, which currently is ignored.

A hookwrapper currently can set the return value / outcome via `force_result`, but it would still run non-hookwrappers before.