### PR TITLE
add specname option to hookimpl

### DIFF
--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -98,7 +98,7 @@ class HookimplMarker(object):
         hookwrapper calls).
 
         If ``specname`` is provided, it will be used instead of the function name when
-        matching the this hook implementation with a hook specification during registration.
+        matching this hook implementation to a hook specification during registration.
 
         """
 

--- a/src/pluggy/hooks.py
+++ b/src/pluggy/hooks.py
@@ -73,6 +73,7 @@ class HookimplMarker(object):
         optionalhook=False,
         tryfirst=False,
         trylast=False,
+        specname=None,
     ):
 
         """ if passed a function, directly sets attributes on the function
@@ -96,6 +97,9 @@ class HookimplMarker(object):
         representing the exception or result outcome of the inner calls (including other
         hookwrapper calls).
 
+        If ``specname`` is provided, it will be used instead of the function name when
+        matching the this hook implementation with a hook specification during registration.
+
         """
 
         def setattr_hookimpl_opts(func):
@@ -107,6 +111,7 @@ class HookimplMarker(object):
                     optionalhook=optionalhook,
                     tryfirst=tryfirst,
                     trylast=trylast,
+                    specname=specname,
                 ),
             )
             return func
@@ -122,6 +127,7 @@ def normalize_hookimpl_opts(opts):
     opts.setdefault("trylast", False)
     opts.setdefault("hookwrapper", False)
     opts.setdefault("optionalhook", False)
+    opts.setdefault("specname", None)
 
 
 if hasattr(inspect, "getfullargspec"):

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -118,10 +118,11 @@ class PluginManager(object):
                 normalize_hookimpl_opts(hookimpl_opts)
                 method = getattr(plugin, name)
                 hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
-                hook = getattr(self.hook, name, None)
+                specname = hookimpl_opts.get('specname') or name
+                hook = getattr(self.hook, specname, None)
                 if hook is None:
-                    hook = _HookCaller(name, self._hookexec)
-                    setattr(self.hook, name, hook)
+                    hook = _HookCaller(specname, self._hookexec)
+                    setattr(self.hook, specname, hook)
                 elif hook.has_spec():
                     self._verify_hook(hook, hookimpl)
                     hook._maybe_apply_history(hookimpl)

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -118,11 +118,11 @@ class PluginManager(object):
                 normalize_hookimpl_opts(hookimpl_opts)
                 method = getattr(plugin, name)
                 hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
-                specname = hookimpl_opts.get("specname") or name
-                hook = getattr(self.hook, specname, None)
+                name = hookimpl_opts.get("specname") or name
+                hook = getattr(self.hook, name, None)
                 if hook is None:
-                    hook = _HookCaller(specname, self._hookexec)
-                    setattr(self.hook, specname, hook)
+                    hook = _HookCaller(name, self._hookexec)
+                    setattr(self.hook, name, hook)
                 elif hook.has_spec():
                     self._verify_hook(hook, hookimpl)
                     hook._maybe_apply_history(hookimpl)

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -118,7 +118,7 @@ class PluginManager(object):
                 normalize_hookimpl_opts(hookimpl_opts)
                 method = getattr(plugin, name)
                 hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
-                specname = hookimpl_opts.get('specname') or name
+                specname = hookimpl_opts.get("specname") or name
                 hook = getattr(self.hook, specname, None)
                 if hook is None:
                     hook = _HookCaller(specname, self._hookexec)

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -187,21 +187,6 @@ def test_hookimpl(name, val):
         assert not hasattr(he_myhook1, name)
 
 
-def test_hookimpl_specname():
-    """Make sure functions decorated with specname get the appropriate tag"""
-
-    @hookimpl()
-    def he_myhook1(arg1):
-        pass
-
-    @hookimpl(specname="name")
-    def he_myhook2(arg1):
-        pass
-
-    assert he_myhook1.example_impl.get("specname") is None
-    assert he_myhook2.example_impl.get("specname") == "name"
-
-
 def test_hookrelay_registry(pm):
     """Verify hook caller instances are registered by name onto the relay
     and can be likewise unregistered."""

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -174,9 +174,7 @@ def test_hookspec(pm):
     assert not pm.hook.he_myhook3.spec.opts["firstresult"]
 
 
-@pytest.mark.parametrize(
-    "name", ["hookwrapper", "optionalhook", "tryfirst", "trylast", "specname"]
-)
+@pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])
 @pytest.mark.parametrize("val", [True, False])
 def test_hookimpl(name, val):
     @hookimpl(**{name: val})
@@ -187,6 +185,21 @@ def test_hookimpl(name, val):
         assert he_myhook1.example_impl.get(name)
     else:
         assert not hasattr(he_myhook1, name)
+
+
+def test_hookimpl_specname():
+    """Make sure functions decorated with specname get the appropriate tag"""
+
+    @hookimpl()
+    def he_myhook1(arg1):
+        pass
+
+    @hookimpl(specname="name")
+    def he_myhook2(arg1):
+        pass
+
+    assert he_myhook1.example_impl.get("specname") is None
+    assert he_myhook2.example_impl.get("specname") == "name"
 
 
 def test_hookrelay_registry(pm):
@@ -216,13 +229,27 @@ def test_hookrelay_registry(pm):
     pm.unregister(plugin)
     assert hook.hello(arg=3) == []
 
-    # the `specname` argument overrides the function name when registering a hook caller
-    class Plugin2(object):
+
+def test_hookrelay_registration_by_specname(pm):
+    """Verify hook caller instances may also be registered by specifying a
+    specname option to the hookimpl"""
+
+    class Api(object):
+        @hookspec
+        def hello(self, arg):
+            "api hook 1"
+
+    pm.add_hookspecs(Api)
+    hook = pm.hook
+    assert hasattr(hook, "hello")
+    assert len(pm.hook.hello.get_hookimpls()) == 0
+
+    class Plugin(object):
         @hookimpl(specname="hello")
         def foo(self, arg):
             return arg + 1
 
-    plugin = Plugin2()
+    plugin = Plugin()
     pm.register(plugin)
     out = hook.hello(arg=3)
     assert out == [4]

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -174,7 +174,9 @@ def test_hookspec(pm):
     assert not pm.hook.he_myhook3.spec.opts["firstresult"]
 
 
-@pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])
+@pytest.mark.parametrize(
+    "name", ["hookwrapper", "optionalhook", "tryfirst", "trylast", "specname"]
+)
 @pytest.mark.parametrize("val", [True, False])
 def test_hookimpl(name, val):
     @hookimpl(**{name: val})
@@ -213,3 +215,15 @@ def test_hookrelay_registry(pm):
     assert not hasattr(hook, "world")
     pm.unregister(plugin)
     assert hook.hello(arg=3) == []
+
+    # the `specname` argument overrides the function name when registering a hook caller
+    class Plugin2(object):
+        @hookimpl(specname="hello")
+        def foo(self, arg):
+            return arg + 1
+
+    plugin = Plugin2()
+    pm.register(plugin)
+    out = hook.hello(arg=3)
+    assert out == [4]
+    assert not hasattr(hook, "world")

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -241,7 +241,7 @@ def test_hookrelay_registration_by_specname(pm):
 
 
 def test_hookrelay_registration_by_specname_raises(pm):
-    """Verify using specname still raises the types of errors during registration as it 
+    """Verify using specname still raises the types of errors during registration as it
     would have without using specname."""
 
     class Api(object):

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -226,4 +226,3 @@ def test_hookrelay_registry(pm):
     pm.register(plugin)
     out = hook.hello(arg=3)
     assert out == [4]
-    assert not hasattr(hook, "world")

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pluggy import HookimplMarker, HookspecMarker
+from pluggy import HookimplMarker, HookspecMarker, PluginValidationError
 from pluggy.hooks import HookImpl
 
 hookspec = HookspecMarker("example")
@@ -238,3 +238,12 @@ def test_hookrelay_registration_by_specname(pm):
     pm.register(plugin)
     out = hook.hello(arg=3)
     assert out == [4]
+
+    class Plugin2(object):
+        @hookimpl(specname="hello")
+        def foo(self, arg, too, many, args):
+            return arg + 1
+
+    with pytest.raises(PluginValidationError):
+        plugin2 = Plugin2()
+        pm.register(plugin2)

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -239,11 +239,22 @@ def test_hookrelay_registration_by_specname(pm):
     out = hook.hello(arg=3)
     assert out == [4]
 
+    # make sure a bad signature still raises an error when using specname
     class Plugin2(object):
         @hookimpl(specname="hello")
         def foo(self, arg, too, many, args):
             return arg + 1
 
     with pytest.raises(PluginValidationError):
-        plugin2 = Plugin2()
-        pm.register(plugin2)
+        pm.register(Plugin2())
+
+    # make sure check_pending still fails if specname doesn't have a
+    # corresponding spec.  EVEN if the function name matches one.
+    class Plugin3(object):
+        @hookimpl(specname="bar")
+        def hello(self, arg):
+            return arg + 1
+
+    with pytest.raises(PluginValidationError):
+        pm.register(Plugin3())
+        pm.check_pending()

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -239,22 +239,34 @@ def test_hookrelay_registration_by_specname(pm):
     out = hook.hello(arg=3)
     assert out == [4]
 
+
+def test_hookrelay_registration_by_specname_raises(pm):
+    """Verify using specname still raises the types of errors during registration as it 
+    would have without using specname."""
+
+    class Api(object):
+        @hookspec
+        def hello(self, arg):
+            "api hook 1"
+
+    pm.add_hookspecs(Api)
+
     # make sure a bad signature still raises an error when using specname
-    class Plugin2(object):
+    class Plugin(object):
         @hookimpl(specname="hello")
         def foo(self, arg, too, many, args):
             return arg + 1
 
     with pytest.raises(PluginValidationError):
-        pm.register(Plugin2())
+        pm.register(Plugin())
 
     # make sure check_pending still fails if specname doesn't have a
     # corresponding spec.  EVEN if the function name matches one.
-    class Plugin3(object):
+    class Plugin2(object):
         @hookimpl(specname="bar")
         def hello(self, arg):
             return arg + 1
 
+    pm.register(Plugin2())
     with pytest.raises(PluginValidationError):
-        pm.register(Plugin3())
         pm.check_pending()


### PR DESCRIPTION
This PR adds a `specname` option to `@hookimpl`.  If `specname` is provided, it will be used instead of the function name when matching this hook implementation to a hook specification during registration (allowing a plugin to register a hook implementation that was not named the same thing as the corresponding `hookspec`). 
(Edited:) This is related to #218 (though likely different than that poster’s intentions)

Most of the interesting discussion is happening in #218 (@RonnyPfannschmidt voiced some opposition to the idea at one point), and you can see my use-case/rationale for wanting this feature in https://github.com/pytest-dev/pluggy/issues/218#issuecomment-578554932.  But I figured since it's a small change, I would submit this so you could see exactly what I was proposing to make the discussion more concrete.  Curious to hear your thoughts.

EDIT:
I should add that I'm not 100% sure this addresses the original poster's request in #218.  They wanted a many-to-one registration, I simply want registration of non-matching function names.