### PR TITLE
[Proposal] Optionally return hook_impl along with results.  

### DIFF
--- a/src/pluggy/callers.py
+++ b/src/pluggy/callers.py
@@ -159,10 +159,14 @@ def _multicall(hook_impls, caller_kwargs, firstresult=False):
     result(s).
 
     ``caller_kwargs`` comes from _HookCaller.__call__().
+    If ``caller_kwargs`` contains a key ``with_impl`` that evaluates to true,
+    results will be returned as 2-tuples of (result, hook_impl) instead of the
+    bare result.
     """
     __tracebackhide__ = True
     results = []
     excinfo = None
+    with_impl = caller_kwargs.pop("with_impl", False)
     try:  # run impl and wrapper setup functions in a loop
         teardowns = []
         try:
@@ -186,7 +190,7 @@ def _multicall(hook_impls, caller_kwargs, firstresult=False):
                 else:
                     res = hook_impl.function(*args)
                     if res is not None:
-                        results.append(res)
+                        results.append((res, hook_impl) if with_impl else res)
                         if firstresult:  # halt further impl calls
                             break
         except BaseException:

--- a/src/pluggy/callers.py
+++ b/src/pluggy/callers.py
@@ -214,6 +214,6 @@ def _multicall(hook_impls, caller_kwargs, firstresult=False):
 
         if with_impl:
             if firstresult:
-                return (outcome.get_result(), impl_hits[0])
+                return (outcome.get_result(), impl_hits[0] if impl_hits else None)
             return list(zip(outcome.get_result(), impl_hits))
         return outcome.get_result()


### PR DESCRIPTION
In implementing pluggy at napari, I have found cases in which I wished I had knowledge of _which_ hookimpl was responsible for returning a result (particularly with `firstresult=True` hooks, where only the first non-None result is returned).

This PR proposal was the least invasive way I could find that would allow us to achieve the result we're after: I modified `_multicall` to peek into `caller_kwargs` for an optional key called `with_impls`.  A user could then do: `plugin_manager.hook.my_hook(arg='something', with_impl=True)` and rather than bare result(s), they would get 2-tuples of `(result, hookimpl)`.

Let me know what you think, and if you're open to this implementation, I'm happy to add tests

UPDATE ... a more complete use case example as requested:
In [napari](https://github.com/napari/napari) (python nD viewer), we allow plugins to extend file format support with a hookspec that takes a file path and expects the plugin to return a _callable_ capable of actually reading the path if the plugin recognizes it as a supported format.  Because the actual reading of the file could be slow, and there may be many plugins that support a given file, we use `firstresult==True` to greedily take the first result that we get.  However, if that plugin then throws an exception, we'd like to know _which_ hookimpl actually claimed the filepath so we can, among other things, assist the user in providing useful traceback info to the plugin developer, but also try the hookcaller sequence again, disabling the failed plugin.  The emphasis is on speed here: given a potentially slow io process, along with a potentially long chain of hookimpls, this greedy approach should be faster than simply collecting all results and then dealing with them after the fact.  That is one example, but it has come up a few times now where it would have been useful to exactly which hookimpl "won" a `firstresult==True` chain

If you'd like to see this in code, [here is block of code](https://github.com/napari/napari/blob/a7c7da78fa1f68bc6de9fe0e669d17fbb5762d11/napari/plugins/utils.py#L100-L153) from a napari PR that does what I describe above. Note that I have vendored `pluggy.callers._multicall` here to achieve the behavior described here.