### PR TITLE
ci/tox: remove pytestfeatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,9 @@ jobs:
     - python: '3.6'
       env: TOXENV=py36-pytestmaster-coverage
     - python: '3.6'
-      env: TOXENV=py36-pytestfeatures-coverage
-    - python: '3.6'
       env: TOXENV=benchmark
     - python: '3.7'
       env: TOXENV=py37-pytestmaster-coverage
-    - python: '3.7'
-      env: TOXENV=py37-pytestfeatures-coverage
 
     - stage: deploy
       python: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
   - TOXENV: "py37"
   - TOXENV: "pypy"
   - TOXENV: "py36-pytestmaster"
-  - TOXENV: "py36-pytestfeatures"
 
 install:
   - echo Installed Pythons

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ extras=testing
 deps=
   coverage: coverage
   pytestmaster: git+https://github.com/pytest-dev/pytest.git@master
-  pytestfeatures: git+https://github.com/pytest-dev/pytest.git@features
 
 [testenv:benchmark]
 commands=pytest {posargs:testing/benchmark.py}


### PR DESCRIPTION
pytest does not use the `features` branch anymore.