### PR TITLE
Handle exceptions in hookwrapper post stage (#244)

### DIFF
--- a/changelog/244.bugfix.rst
+++ b/changelog/244.bugfix.rst
@@ -1,0 +1,6 @@
+Exceptions raised by hook wrappers in the post-yield part propagate
+to outer wrappers boxed into ``_Result`` container.
+Previously no other teardown code was run in other hooks after such exception.
+
+* Use ``try-yield-finally`` pattern in hook wrappers intended for setup and teardown.
+* Raise an exception to convert hook result into failure.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -402,9 +402,19 @@ the final result(s) returned back to the caller using the
 :py:meth:`~pluggy._callers._Result.force_result` or
 :py:meth:`~pluggy._callers._Result.get_result` methods.
 
+If a wrapper is intended for setup and tear down of other stuff,
+do not forget to surround ``yield`` and ``outcome.get_result()``
+with ``try`` and ``finally`` exactly as it is recommended for
+:py:func:`@contextlib.contextmanager <python:contextlib.contextmanager>`.
+``outcome.get_result()`` could raise an exception if some other hook failed.
+For future compatibility it is better to assume that ``yield`` could
+throw as well.
+
 .. note::
     Hook wrappers can **not** return results (as per generator function
     semantics); they can only modify them using the ``_Result`` API.
+    However an exception following ``yield`` implicitly replaces result
+    for the outer wrappers if there are any of them.
 
 Also see the :ref:`pytest:hookwrapper` section in the ``pytest`` docs.
 

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -39,15 +39,17 @@ def _multicall(
                             )
 
                 if hook_impl.hookwrapper:
+                    # If this cast is not valid, a type error is raised below,
+                    # which is the desired response.
+                    res = hook_impl.function(*args)
+                    gen = cast(Generator[None, _Result[object], None], res)
+
                     try:
-                        # If this cast is not valid, a type error is raised below,
-                        # which is the desired response.
-                        res = hook_impl.function(*args)
-                        gen = cast(Generator[None, _Result[object], None], res)
                         next(gen)  # first yield
-                        teardowns.append(gen)
                     except StopIteration:
                         _raise_wrapfail(gen, "did not yield")
+
+                    teardowns.append(gen)
                 else:
                     res = hook_impl.function(*args)
                     if res is not None:

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -122,6 +122,18 @@ def test_hookwrapper_not_yield() -> None:
         MC([m1], {})
 
 
+def test_hookwrapper_yield_not_executed() -> None:
+    @hookimpl(hookwrapper=True)
+    def m1():
+        if False:
+            yield  # type: ignore[unreachable]
+        return
+
+    with pytest.raises(RuntimeError) as ex:
+        MC([m1], {})
+    assert "did not yield" in str(ex.value)
+
+
 def test_hookwrapper_too_many_yield() -> None:
     out = []
 


### PR DESCRIPTION
Make hook wrappers more reliable by calling remaining tear down stages even an exception thrown in some wrapper during this step. Currently such code could be called too late when garbage collector deletes generator objects.

Fixes #244