### PR TITLE
Allow running `tox -e linting` with any python3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,11 @@ repos:
     hooks:
     -   id: black
         args: [--safe, --quiet]
-        language_version: python3.6
 -   repo: https://github.com/asottile/blacken-docs
     rev: v0.5.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==19.10b0]
-        language_version: python3.6
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
@@ -25,7 +23,6 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-        language_version: python3.6
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.3.0
     hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps=
 
 [testenv:linting]
 skip_install = true
-basepython = python3.6
+basepython = python3
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
 


### PR DESCRIPTION
I'm not an expert, but I can't run it otherwise if I only have Python 3.8 installed.