### PR TITLE
Remove deprecated _Result.result

### DIFF
--- a/changelog/265.removal.rst
+++ b/changelog/265.removal.rst
@@ -1,0 +1,3 @@
+Remove the ``_Result.result`` property. Use ``_Result.get_result()`` instead.
+Note that unlike ``result``, ``get_result()`` raises the exception if the hook raised.
+The deprecation was announced in release ``0.6.0``.

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -37,13 +37,6 @@ class _Result(object):
     def excinfo(self):
         return self._excinfo
 
-    @property
-    def result(self):
-        """Get the result(s) for this hook call (DEPRECATED in favor of ``get_result()``)."""
-        msg = "Use get_result() which forces correct exception handling"
-        warnings.warn(DeprecationWarning(msg), stacklevel=2)
-        return self._result
-
     @classmethod
     def from_call(cls, func):
         __tracebackhide__ = True

--- a/testing/test_deprecations.py
+++ b/testing/test_deprecations.py
@@ -2,17 +2,10 @@
 Deprecation warnings testing roundup.
 """
 import pytest
-from pluggy.callers import _Result
 from pluggy import PluginManager, HookimplMarker, HookspecMarker
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
-
-
-def test_result_deprecated():
-    r = _Result(10, None)
-    with pytest.deprecated_call():
-        assert r.result == 10
 
 
 def test_implprefix_deprecated():


### PR DESCRIPTION
Since master is now 1.0, we can remove deprecated stuff.