### PR TITLE
Add Github Actions CI for Windows jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,141 @@
+name: main
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [
+          "windows-py27",
+          "windows-py35",
+          "windows-py36",
+          "windows-py37",
+          "windows-pypy2",
+          "windows-pypy3",
+
+          # Eventually should convert travis to Github Actions as well.
+          # Commented stuff is in preparation for that.
+          # "ubuntu-py27",
+          # "ubuntu-py35",
+          # "ubuntu-py36",
+          # "ubuntu-py36-pytestmaster",
+          # "ubuntu-py37",
+          # "ubuntu-py38",
+          # "ubuntu-pypy2",
+          # "ubuntu-pypy3",
+          # "ubuntu-benchmark",
+
+          # "linting",
+          # "docs",
+        ]
+
+        include:
+          - name: "windows-py27"
+            python: "2.7"
+            os: windows-latest
+            tox_env: "py27"
+          - name: "windows-py35"
+            python: "3.5"
+            os: windows-latest
+            tox_env: "py35"
+          - name: "windows-py36"
+            python: "3.6"
+            os: windows-latest
+            tox_env: "py36"
+          - name: "windows-py37"
+            python: "3.7"
+            os: windows-latest
+            tox_env: "py37"
+          - name: "windows-pypy2"
+            python: "pypy2"
+            os: windows-latest
+            tox_env: "pypy"
+          - name: "windows-pypy3"
+            python: "pypy3"
+            os: windows-latest
+            tox_env: "pypy3"
+          # - name: "ubuntu-py27"
+          #   python: "2.7"
+          #   os: ubuntu-latest
+          #   tox_env: "py27"
+          #   use_coverage: true
+          # - name: "ubuntu-py35"
+          #   python: "3.5"
+          #   os: ubuntu-latest
+          #   tox_env: "py35"
+          # - name: "ubuntu-py36"
+          #   python: "3.6"
+          #   os: ubuntu-latest
+          #   tox_env: "py36"
+          # - name: "ubuntu-py36-pytestmaster"
+          #   python: "3.6"
+          #   os: ubuntu-latest
+          #   tox_env: "py36-pytestmaster"
+          # - name: "ubuntu-py37"
+          #   python: "3.7"
+          #   os: ubuntu-latest
+          #   tox_env: "py37"
+          # - name: "ubuntu-py38"
+          #   python: "3.8"
+          #   os: ubuntu-latest
+          #   tox_env: "py38"
+          # - name: "ubuntu-pypy2"
+          #   python: "pypy2"
+          #   os: ubuntu-latest
+          #   tox_env: "pypy"
+          # - name: "ubuntu-pypy3"
+          #   python: "pypy3"
+          #   os: ubuntu-latest
+          #   tox_env: "pypy3"
+          # - name: "ubuntu-benchmark"
+          #   python: "3.8"
+          #   os: ubuntu-latest
+          #   tox_env: "benchmark"
+          # - name: "linting"
+          #   python: "3.8"
+          #   os: ubuntu-latest
+          #   tox_env: "linting"
+          # - name: "docs"
+          #   python: "3.8"
+          #   os: ubuntu-latest
+          #   tox_env: "docs"
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox coverage
+
+    - name: Test without coverage
+      if: "! matrix.use_coverage"
+      run: "tox -e ${{ matrix.tox_env }}"
+
+    # - name: Test with coverage
+    #   if: "matrix.use_coverage"
+    #   env:
+    #     _PYTEST_TOX_COVERAGE_RUN: "coverage run -m"
+    #     COVERAGE_PROCESS_START: ".coveragerc"
+    #     _PYTEST_TOX_EXTRA_DEP: "coverage-enable-subprocess"
+    #   run: "tox -e ${{ matrix.tox_env }}"


### PR DESCRIPTION
This can replace Appveyor. I was prompted to this by https://github.com/pytest-dev/pluggy/pull/264#issuecomment-638974445 but also to match what pytest is using.

The idea is to replace Travis as well but that requires some more work.

Github Actions doesn't support Python 3.4, so it's dropped compared to Appveyor, however it is still covered by Travis.