### PR TITLE
Remove deprecated implprefix support

### DIFF
--- a/changelog/116.removal.rst
+++ b/changelog/116.removal.rst
@@ -1,0 +1,3 @@
+Remove deprecated ``implprefix`` support.
+Decorate hook implementations using an instance of HookimplMarker instead.
+The deprecation was announced in release ``0.7.0``.

--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -64,23 +64,13 @@ class PluginManager(object):
     which will subsequently send debug information to the trace helper.
     """
 
-    def __init__(self, project_name, implprefix=None):
-        """If ``implprefix`` is given implementation functions
-        will be recognized if their name matches the ``implprefix``. """
+    def __init__(self, project_name):
         self.project_name = project_name
         self._name2plugin = {}
         self._plugin2hookcallers = {}
         self._plugin_distinfo = []
         self.trace = _tracing.TagTracer().get("pluginmanage")
         self.hook = _HookRelay()
-        if implprefix is not None:
-            warnings.warn(
-                "Support for the `implprefix` arg is now deprecated and will "
-                "be removed in an upcoming release. Please use HookimplMarker.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        self._implprefix = implprefix
         self._inner_hookexec = lambda hook, methods, kwargs: _multicall(
             methods,
             kwargs,
@@ -141,16 +131,6 @@ class PluginManager(object):
         if res is not None and not isinstance(res, dict):
             # false positive
             res = None
-        # TODO: remove when we drop implprefix in 1.0
-        elif res is None and self._implprefix and name.startswith(self._implprefix):
-            _warn_for_function(
-                DeprecationWarning(
-                    "The `implprefix` system is deprecated please decorate "
-                    "this function using an instance of HookimplMarker."
-                ),
-                method,
-            )
-            res = {}
         return res
 
     def unregister(self, plugin=None, name=None):

--- a/testing/test_deprecations.py
+++ b/testing/test_deprecations.py
@@ -2,22 +2,10 @@
 Deprecation warnings testing roundup.
 """
 import pytest
-from pluggy import PluginManager, HookimplMarker, HookspecMarker
+from pluggy import HookimplMarker, HookspecMarker
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
-
-
-def test_implprefix_deprecated():
-    with pytest.deprecated_call():
-        pm = PluginManager("blah", implprefix="blah_")
-
-    class Plugin:
-        def blah_myhook(self, arg1):
-            return arg1
-
-    with pytest.deprecated_call():
-        pm.register(Plugin())
 
 
 def test_callhistoric_proc_deprecated(pm):


### PR DESCRIPTION
This has been deprecated for a while, let's remove it in pluggy 1.0.

Refs #116. Fixes #145.

pytest no longer uses it.

tox doesn't use it.

devpi [mentions it](https://github.com/devpi/devpi/search?q=implprefix&unscoped_q=implprefix) with comment "support old plugins, but emit deprecation warnings", does so in a future-compatible manner however (doesn't pass the `implprefix` argument to `PluginManager`, which this PR removes, but sets `_implprefix` attribute instead, which this PR now ignores). devpi uses `pluggy>=0.6.0,<1.0` so it's fine anyway.