### PR TITLE
Fix unused import in master, move some jobs from Travis to GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,10 @@ jobs:
           # "ubuntu-py38",
           # "ubuntu-pypy2",
           # "ubuntu-pypy3",
-          # "ubuntu-benchmark",
+          "ubuntu-benchmark",
 
-          # "linting",
-          # "docs",
+          "linting",
+          "docs",
         ]
 
         include:
@@ -100,18 +100,18 @@ jobs:
           #   python: "pypy3"
           #   os: ubuntu-latest
           #   tox_env: "pypy3"
-          # - name: "ubuntu-benchmark"
-          #   python: "3.8"
-          #   os: ubuntu-latest
-          #   tox_env: "benchmark"
-          # - name: "linting"
-          #   python: "3.8"
-          #   os: ubuntu-latest
-          #   tox_env: "linting"
-          # - name: "docs"
-          #   python: "3.8"
-          #   os: ubuntu-latest
-          #   tox_env: "docs"
+          - name: "ubuntu-benchmark"
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: "benchmark"
+          - name: "linting"
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: "linting"
+          - name: "docs"
+            python: "3.8"
+            os: ubuntu-latest
+            tox_env: "docs"
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,6 @@ stages:
 
 jobs:
   include:
-    - python: '3.6'
-      env: TOXENV=linting
-      cache:
-        directories:
-          - $HOME/.cache/pre-commit
-    - python: '3.6'
-      env: TOXENV=docs
     - python: '2.7'
       env: TOXENV=py27-coverage
     - python: '3.5'
@@ -32,8 +25,6 @@ jobs:
       env: TOXENV=py38-coverage
     - python: '3.6'
       env: TOXENV=py36-pytestmaster-coverage
-    - python: '3.6'
-      env: TOXENV=benchmark
     - python: '3.7'
       env: TOXENV=py37-pytestmaster-coverage
 

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -2,7 +2,6 @@
 Hook wrapper "result" utilities.
 """
 import sys
-import warnings
 
 _py3 = sys.version_info > (3, 0)
 


### PR DESCRIPTION
Because we moved things around between submitting and merging the PRs, the unused import slipped into master, which causes the CI to fail, so fix that.

Also move the `linting`, `docs` and `benchmark` jobs to GHA because it's nicer and provides a visible "Check" status. What's left on travis require coverage which I can't set up no GHA myself, I think.