### PR TITLE
Remove pytestfeatures tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=linting,docs,py{27,35,36,37,38,py,py3},py{36,37}-pytest{master,features}
+envlist=linting,docs,py{27,35,36,37,38,py,py3},py{36,37}-pytest{master}
 
 [testenv]
 commands=


### PR DESCRIPTION
Was missed in 30a2f7c691c32e7ceb29ce52063773c21d3a2a0e.