### PR TITLE
fix: dictionary changed size during iteration iterating on importlib_metadata.distributions()

### DIFF
--- a/src/pluggy/manager.py
+++ b/src/pluggy/manager.py
@@ -263,7 +263,7 @@ class PluginManager:
         :return: return the number of loaded plugins by this call.
         """
         count = 0
-        for dist in importlib_metadata.distributions():
+        for dist in list(importlib_metadata.distributions()):
             for ep in dist.entry_points:
                 if (
                     ep.group != group


### PR DESCRIPTION
Simple fix for this error: https://github.com/python/importlib_metadata/issues/293
(similar to https://github.com/pytest-dev/py/issues/218)