### PR TITLE
Restore use_scm_version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,4 @@ from setuptools import setup
 
 
 if __name__ == "__main__":
-    setup()
+    setup(use_scm_version={"write_to": "src/pluggy/_version.py"})

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,7 @@ deps=
 commands=pytest {posargs:testing/benchmark.py}
 deps=
   pytest
-  # Once pytest lifts its pluggy<1.0 constraint, the pytest-benchmark
-  # constraint can be removed.
-  pytest-benchmark==3.1.1
+  pytest-benchmark
 
 [testenv:linting]
 skip_install = true


### PR DESCRIPTION
Despite adding it also to pyproject.toml, it doesn't work for `pip
install -e .` and probably other stuff like that, so it got version
`0.0.0`.