### PR TITLE
docs: hookimpl must be hashable

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -224,6 +224,8 @@ which has been appropriately marked.
 *hookimpls* are loaded from a plugin using the
 :py:meth:`~pluggy.PluginManager.register()` method:
 
+*hookimpls* must be hashable.
+
 .. code-block:: python
 
     import sys


### PR DESCRIPTION
Closes #327 