### PR TITLE
Add type annotations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,15 @@ source = pluggy/
   */lib/python*/site-packages/pluggy/
   */pypy*/site-packages/pluggy/
   *\Lib\site-packages\pluggy\
+
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    if TYPE_CHECKING:
+
+    if __name__ == .__main__.:
+
+    # Ignore coverage on lines solely with `...`
+    ^\s*\.\.\.\s*$

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.mypy_cache/
 nosetests.xml
 coverage.xml
 *,cover

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,14 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: flake8
+        additional_dependencies: [flake8-typing-imports]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+    -   id: mypy
+        files: ^(src/|testing/)
+        args: []
+        additional_dependencies: [pytest]
 -   repo: local
     hooks:
     -   id: rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ html_static_path = ["_static"]
 # (source start file, name, description, authors, manual section).
 man_pages = [(master_doc, "pluggy", "pluggy Documentation", [author], 1)]
 
+autodoc_typehints = "none"
 
 # -- Options for Texinfo output -------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ template = "changelog/_template.rst"
 [tool.mypy]
 mypy_path = "src"
 check_untyped_defs = true
+# Hopefully we can set this someday!
 # disallow_any_expr = true
 disallow_any_generics = true
 disallow_any_unimported = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,24 @@ template = "changelog/_template.rst"
   directory = "trivial"
   name = "Trivial/Internal Changes"
   showcontent = true
+
+[tool.mypy]
+mypy_path = "src"
+check_untyped_defs = true
+# disallow_any_expr = true
+disallow_any_generics = true
+disallow_any_unimported = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+ignore_missing_imports = true
+implicit_reexport = false
+no_implicit_optional = true
+show_error_codes = true
+strict_equality = true
+strict_optional = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -14,5 +14,5 @@ __all__ = [
 ]
 
 from ._manager import PluginManager, PluginValidationError
-from ._callers import HookCallError
+from ._result import HookCallError
 from ._hooks import HookspecMarker, HookimplMarker

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -2,18 +2,28 @@
 Call loop machinery
 """
 import sys
+from typing import cast, Generator, List, Mapping, Sequence, Union
+from typing import TYPE_CHECKING
 
 from ._result import HookCallError, _Result, _raise_wrapfail
 
+if TYPE_CHECKING:
+    from ._hooks import HookImpl
 
-def _multicall(hook_name, hook_impls, caller_kwargs, firstresult):
+
+def _multicall(
+    hook_name: str,
+    hook_impls: Sequence["HookImpl"],
+    caller_kwargs: Mapping[str, object],
+    firstresult: bool,
+) -> Union[object, List[object]]:
     """Execute a call into multiple python functions/methods and return the
     result(s).
 
     ``caller_kwargs`` comes from _HookCaller.__call__().
     """
     __tracebackhide__ = True
-    results = []
+    results: List[object] = []
     excinfo = None
     try:  # run impl and wrapper setup functions in a loop
         teardowns = []
@@ -30,7 +40,10 @@ def _multicall(hook_name, hook_impls, caller_kwargs, firstresult):
 
                 if hook_impl.hookwrapper:
                     try:
-                        gen = hook_impl.function(*args)
+                        # If this cast is not valid, a type error is raised below,
+                        # which is the desired response.
+                        res = hook_impl.function(*args)
+                        gen = cast(Generator[None, _Result[object], None], res)
                         next(gen)  # first yield
                         teardowns.append(gen)
                     except StopIteration:
@@ -42,10 +55,16 @@ def _multicall(hook_name, hook_impls, caller_kwargs, firstresult):
                         if firstresult:  # halt further impl calls
                             break
         except BaseException:
-            excinfo = sys.exc_info()
+            _excinfo = sys.exc_info()
+            assert _excinfo[0] is not None
+            assert _excinfo[1] is not None
+            assert _excinfo[2] is not None
+            excinfo = (_excinfo[0], _excinfo[1], _excinfo[2])
     finally:
         if firstresult:  # first result hooks return a single value
-            outcome = _Result(results[0] if results else None, excinfo)
+            outcome: _Result[Union[object, List[object]]] = _Result(
+                results[0] if results else None, excinfo
+            )
         else:
             outcome = _Result(results, excinfo)
 

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -69,7 +69,7 @@ class HookspecMarker:
         historic: bool = False,
         warn_on_impl: Optional[Warning] = None,
     ) -> _F:
-        pass
+        ...
 
     @overload  # noqa: F811
     def __call__(  # noqa: F811
@@ -79,7 +79,7 @@ class HookspecMarker:
         historic: bool = ...,
         warn_on_impl: Optional[Warning] = ...,
     ) -> Callable[[_F], _F]:
-        pass
+        ...
 
     def __call__(  # noqa: F811
         self,
@@ -140,7 +140,7 @@ class HookimplMarker:
         trylast: bool = ...,
         specname: Optional[str] = ...,
     ) -> _F:
-        pass
+        ...
 
     @overload  # noqa: F811
     def __call__(  # noqa: F811
@@ -152,7 +152,7 @@ class HookimplMarker:
         trylast: bool = ...,
         specname: Optional[str] = ...,
     ) -> Callable[[_F], _F]:
-        pass
+        ...
 
     def __call__(  # noqa: F811
         self,
@@ -270,7 +270,7 @@ class _HookRelay:
     if TYPE_CHECKING:
 
         def __getattr__(self, name: str) -> "_HookCaller":
-            pass
+            ...
 
 
 class _HookCaller:

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -4,6 +4,50 @@ Internal hook annotation, representation and calling machinery.
 import inspect
 import sys
 import warnings
+from types import ModuleType
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    overload,
+    Sequence,
+    Tuple,
+    TypeVar,
+    TYPE_CHECKING,
+    Union,
+)
+
+from ._result import _Result
+
+if TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+
+_T = TypeVar("_T")
+_F = TypeVar("_F", bound=Callable[..., object])
+_Namespace = Union[ModuleType, type]
+_Plugin = object
+_HookExec = Callable[
+    [str, Sequence["HookImpl"], Mapping[str, object], bool],
+    Union[object, List[object]],
+]
+_HookImplFunction = Callable[..., Union[_T, Generator[None, _Result[_T], None]]]
+if TYPE_CHECKING:
+
+    class _HookSpecOpts(TypedDict):
+        firstresult: bool
+        historic: bool
+        warn_on_impl: Optional[Warning]
+
+    class _HookImplOpts(TypedDict):
+        hookwrapper: bool
+        optionalhook: bool
+        tryfirst: bool
+        trylast: bool
+        specname: Optional[str]
 
 
 class HookspecMarker:
@@ -14,12 +58,36 @@ class HookspecMarker:
     if the :py:class:`.PluginManager` uses the same project_name.
     """
 
-    def __init__(self, project_name):
+    def __init__(self, project_name: str) -> None:
         self.project_name = project_name
 
+    @overload
     def __call__(
-        self, function=None, firstresult=False, historic=False, warn_on_impl=None
-    ):
+        self,
+        function: _F,
+        firstresult: bool = False,
+        historic: bool = False,
+        warn_on_impl: Optional[Warning] = None,
+    ) -> _F:
+        pass
+
+    @overload  # noqa: F811
+    def __call__(  # noqa: F811
+        self,
+        function: None = ...,
+        firstresult: bool = ...,
+        historic: bool = ...,
+        warn_on_impl: Optional[Warning] = ...,
+    ) -> Callable[[_F], _F]:
+        pass
+
+    def __call__(  # noqa: F811
+        self,
+        function: Optional[_F] = None,
+        firstresult: bool = False,
+        historic: bool = False,
+        warn_on_impl: Optional[Warning] = None,
+    ) -> Union[_F, Callable[[_F], _F]]:
         """if passed a function, directly sets attributes on the function
         which will make it discoverable to :py:meth:`.PluginManager.add_hookspecs`.
         If passed no function, returns a decorator which can be applied to a function
@@ -34,18 +102,15 @@ class HookspecMarker:
 
         """
 
-        def setattr_hookspec_opts(func):
+        def setattr_hookspec_opts(func: _F) -> _F:
             if historic and firstresult:
                 raise ValueError("cannot have a historic firstresult hook")
-            setattr(
-                func,
-                self.project_name + "_spec",
-                dict(
-                    firstresult=firstresult,
-                    historic=historic,
-                    warn_on_impl=warn_on_impl,
-                ),
-            )
+            opts: "_HookSpecOpts" = {
+                "firstresult": firstresult,
+                "historic": historic,
+                "warn_on_impl": warn_on_impl,
+            }
+            setattr(func, self.project_name + "_spec", opts)
             return func
 
         if function is not None:
@@ -62,19 +127,42 @@ class HookimplMarker:
     if the :py:class:`.PluginManager` uses the same project_name.
     """
 
-    def __init__(self, project_name):
+    def __init__(self, project_name: str) -> None:
         self.project_name = project_name
 
+    @overload
     def __call__(
         self,
-        function=None,
-        hookwrapper=False,
-        optionalhook=False,
-        tryfirst=False,
-        trylast=False,
-        specname=None,
-    ):
+        function: _F,
+        hookwrapper: bool = ...,
+        optionalhook: bool = ...,
+        tryfirst: bool = ...,
+        trylast: bool = ...,
+        specname: Optional[str] = ...,
+    ) -> _F:
+        pass
 
+    @overload  # noqa: F811
+    def __call__(  # noqa: F811
+        self,
+        function: None = ...,
+        hookwrapper: bool = ...,
+        optionalhook: bool = ...,
+        tryfirst: bool = ...,
+        trylast: bool = ...,
+        specname: Optional[str] = ...,
+    ) -> Callable[[_F], _F]:
+        pass
+
+    def __call__(  # noqa: F811
+        self,
+        function: Optional[_F] = None,
+        hookwrapper: bool = False,
+        optionalhook: bool = False,
+        tryfirst: bool = False,
+        trylast: bool = False,
+        specname: Optional[str] = None,
+    ) -> Union[_F, Callable[[_F], _F]]:
         """if passed a function, directly sets attributes on the function
         which will make it discoverable to :py:meth:`.PluginManager.register`.
         If passed no function, returns a decorator which can be applied to a
@@ -101,18 +189,15 @@ class HookimplMarker:
 
         """
 
-        def setattr_hookimpl_opts(func):
-            setattr(
-                func,
-                self.project_name + "_impl",
-                dict(
-                    hookwrapper=hookwrapper,
-                    optionalhook=optionalhook,
-                    tryfirst=tryfirst,
-                    trylast=trylast,
-                    specname=specname,
-                ),
-            )
+        def setattr_hookimpl_opts(func: _F) -> _F:
+            opts: "_HookImplOpts" = {
+                "hookwrapper": hookwrapper,
+                "optionalhook": optionalhook,
+                "tryfirst": tryfirst,
+                "trylast": trylast,
+                "specname": specname,
+            }
+            setattr(func, self.project_name + "_impl", opts)
             return func
 
         if function is None:
@@ -121,7 +206,7 @@ class HookimplMarker:
             return setattr_hookimpl_opts(function)
 
 
-def normalize_hookimpl_opts(opts):
+def normalize_hookimpl_opts(opts: "_HookImplOpts") -> None:
     opts.setdefault("tryfirst", False)
     opts.setdefault("trylast", False)
     opts.setdefault("hookwrapper", False)
@@ -132,7 +217,7 @@ def normalize_hookimpl_opts(opts):
 _PYPY = hasattr(sys, "pypy_version_info")
 
 
-def varnames(func):
+def varnames(func: object) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
     """Return tuple of positional and keywrord argument names for a function,
     method, class or callable.
 
@@ -164,11 +249,13 @@ def varnames(func):
 
     # strip any implicit instance arg
     # pypy3 uses "obj" instead of "self" for default dunder methods
-    implicit_names = ("self",) if not _PYPY else ("self", "obj")
+    if not _PYPY:
+        implicit_names: Tuple[str, ...] = ("self",)
+    else:
+        implicit_names = ("self", "obj")
     if args:
-        if inspect.ismethod(func) or (
-            "." in getattr(func, "__qualname__", ()) and args[0] in implicit_names
-        ):
+        qualname: str = getattr(func, "__qualname__", "")
+        if inspect.ismethod(func) or ("." in qualname and args[0] in implicit_names):
             args = args[1:]
 
     return args, kwargs
@@ -180,47 +267,65 @@ class _HookRelay:
 
     """
 
+    if TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> "_HookCaller":
+            pass
+
 
 class _HookCaller:
-    def __init__(self, name, hook_execute, specmodule_or_class=None, spec_opts=None):
+    def __init__(
+        self,
+        name: str,
+        hook_execute: _HookExec,
+        specmodule_or_class: Optional[_Namespace] = None,
+        spec_opts: Optional["_HookSpecOpts"] = None,
+    ) -> None:
         self.name = name
-        self._wrappers = []
-        self._nonwrappers = []
+        self._wrappers: List[HookImpl] = []
+        self._nonwrappers: List[HookImpl] = []
         self._hookexec = hook_execute
-        self._call_history = None
-        self.spec = None
+        self._call_history: Optional[
+            List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
+        ] = None
+        self.spec: Optional[HookSpec] = None
         if specmodule_or_class is not None:
             assert spec_opts is not None
             self.set_specification(specmodule_or_class, spec_opts)
 
-    def has_spec(self):
+    def has_spec(self) -> bool:
         return self.spec is not None
 
-    def set_specification(self, specmodule_or_class, spec_opts):
+    def set_specification(
+        self,
+        specmodule_or_class: _Namespace,
+        spec_opts: "_HookSpecOpts",
+    ) -> None:
         assert not self.has_spec()
         self.spec = HookSpec(specmodule_or_class, self.name, spec_opts)
         if spec_opts.get("historic"):
             self._call_history = []
 
-    def is_historic(self):
+    def is_historic(self) -> bool:
         return self._call_history is not None
 
-    def _remove_plugin(self, plugin):
-        def remove(wrappers):
+    def _remove_plugin(self, plugin: _Plugin) -> None:
+        def remove(wrappers: List[HookImpl]) -> Optional[bool]:
             for i, method in enumerate(wrappers):
                 if method.plugin == plugin:
                     del wrappers[i]
                     return True
+            return None
 
         if remove(self._wrappers) is None:
             if remove(self._nonwrappers) is None:
                 raise ValueError(f"plugin {plugin!r} not found")
 
-    def get_hookimpls(self):
+    def get_hookimpls(self) -> List["HookImpl"]:
         # Order is important for _hookexec
         return self._nonwrappers + self._wrappers
 
-    def _add_hookimpl(self, hookimpl):
+    def _add_hookimpl(self, hookimpl: "HookImpl") -> None:
         """Add an implementation to the callback chain."""
         if hookimpl.hookwrapper:
             methods = self._wrappers
@@ -238,10 +343,10 @@ class _HookCaller:
                 i -= 1
             methods.insert(i + 1, hookimpl)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<_HookCaller {self.name!r}>"
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> Any:
         if args:
             raise TypeError("hook calling supports only keyword arguments")
         assert not self.is_historic()
@@ -258,34 +363,49 @@ class _HookCaller:
                     )
                     break
 
-            firstresult = self.spec.opts.get("firstresult")
+            firstresult = self.spec.opts.get("firstresult", False)
         else:
             firstresult = False
 
         return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
 
-    def call_historic(self, result_callback=None, kwargs=None):
+    def call_historic(
+        self,
+        result_callback: Optional[Callable[[Any], None]] = None,
+        kwargs: Optional[Mapping[str, object]] = None,
+    ) -> None:
         """Call the hook with given ``kwargs`` for all registered plugins and
         for all plugins which will be registered afterwards.
 
         If ``result_callback`` is not ``None`` it will be called for for each
         non-``None`` result obtained from a hook implementation.
         """
-        self._call_history.append((kwargs or {}, result_callback))
+        assert self._call_history is not None
+        kwargs = kwargs or {}
+        self._call_history.append((kwargs, result_callback))
         # Historizing hooks don't return results.
         # Remember firstresult isn't compatible with historic.
         res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
         if result_callback is None:
             return
-        for x in res or []:
-            result_callback(x)
+        if isinstance(res, list):
+            for x in res:
+                result_callback(x)
 
-    def call_extra(self, methods, kwargs):
+    def call_extra(
+        self, methods: Sequence[Callable[..., object]], kwargs: Mapping[str, object]
+    ) -> Any:
         """Call the hook with some additional temporarily participating
         methods using the specified ``kwargs`` as call parameters."""
         old = list(self._nonwrappers), list(self._wrappers)
         for method in methods:
-            opts = dict(hookwrapper=False, trylast=False, tryfirst=False)
+            opts: "_HookImplOpts" = {
+                "hookwrapper": False,
+                "optionalhook": False,
+                "trylast": False,
+                "tryfirst": False,
+                "specname": None,
+            }
             hookimpl = HookImpl(None, "<temp>", method, opts)
             self._add_hookimpl(hookimpl)
         try:
@@ -293,33 +413,45 @@ class _HookCaller:
         finally:
             self._nonwrappers, self._wrappers = old
 
-    def _maybe_apply_history(self, method):
+    def _maybe_apply_history(self, method: "HookImpl") -> None:
         """Apply call history to a new hookimpl if it is marked as historic."""
         if self.is_historic():
+            assert self._call_history is not None
             for kwargs, result_callback in self._call_history:
                 res = self._hookexec(self.name, [method], kwargs, False)
                 if res and result_callback is not None:
+                    # XXX: remember firstresult isn't compat with historic
+                    assert isinstance(res, list)
                     result_callback(res[0])
 
 
 class HookImpl:
-    def __init__(self, plugin, plugin_name, function, hook_impl_opts):
+    def __init__(
+        self,
+        plugin: _Plugin,
+        plugin_name: str,
+        function: _HookImplFunction[object],
+        hook_impl_opts: "_HookImplOpts",
+    ) -> None:
         self.function = function
         self.argnames, self.kwargnames = varnames(self.function)
         self.plugin = plugin
         self.opts = hook_impl_opts
         self.plugin_name = plugin_name
-        self.__dict__.update(hook_impl_opts)
+        self.hookwrapper = hook_impl_opts["hookwrapper"]
+        self.optionalhook = hook_impl_opts["optionalhook"]
+        self.tryfirst = hook_impl_opts["tryfirst"]
+        self.trylast = hook_impl_opts["trylast"]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<HookImpl plugin_name={self.plugin_name!r}, plugin={self.plugin!r}>"
 
 
 class HookSpec:
-    def __init__(self, namespace, name, opts):
+    def __init__(self, namespace: _Namespace, name: str, opts: "_HookSpecOpts") -> None:
         self.namespace = namespace
-        self.function = function = getattr(namespace, name)
+        self.function: Callable[..., object] = getattr(namespace, name)
         self.name = name
-        self.argnames, self.kwargnames = varnames(function)
+        self.argnames, self.kwargnames = varnames(self.function)
         self.opts = opts
         self.warn_on_impl = opts.get("warn_on_impl")

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -2,9 +2,30 @@
 Hook wrapper "result" utilities.
 """
 import sys
+from types import TracebackType
+from typing import (
+    Callable,
+    cast,
+    Generator,
+    Generic,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from typing import NoReturn
 
 
-def _raise_wrapfail(wrap_controller, msg):
+_ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
+_T = TypeVar("_T")
+
+
+def _raise_wrapfail(
+    wrap_controller: Generator[None, "_Result[_T]", None], msg: str
+) -> "NoReturn":
     co = wrap_controller.gi_code
     raise RuntimeError(
         "wrap_controller at %r %s:%d %s"
@@ -16,27 +37,31 @@ class HookCallError(Exception):
     """Hook was called wrongly."""
 
 
-class _Result:
-    def __init__(self, result, excinfo):
+class _Result(Generic[_T]):
+    def __init__(self, result: Optional[_T], excinfo: Optional[_ExcInfo]) -> None:
         self._result = result
         self._excinfo = excinfo
 
     @property
-    def excinfo(self):
+    def excinfo(self) -> Optional[_ExcInfo]:
         return self._excinfo
 
     @classmethod
-    def from_call(cls, func):
+    def from_call(cls, func: Callable[[], _T]) -> "_Result[_T]":
         __tracebackhide__ = True
         result = excinfo = None
         try:
             result = func()
         except BaseException:
-            excinfo = sys.exc_info()
+            _excinfo = sys.exc_info()
+            assert _excinfo[0] is not None
+            assert _excinfo[1] is not None
+            assert _excinfo[2] is not None
+            excinfo = (_excinfo[0], _excinfo[1], _excinfo[2])
 
         return cls(result, excinfo)
 
-    def force_result(self, result):
+    def force_result(self, result: _T) -> None:
         """Force the result(s) to ``result``.
 
         If the hook was marked as a ``firstresult`` a single value should
@@ -46,7 +71,7 @@ class _Result:
         self._result = result
         self._excinfo = None
 
-    def get_result(self):
+    def get_result(self) -> _T:
         """Get the result(s) for this hook call.
 
         If the hook was marked as a ``firstresult`` only a single value
@@ -54,7 +79,7 @@ class _Result:
         """
         __tracebackhide__ = True
         if self._excinfo is None:
-            return self._result
+            return cast(_T, self._result)
         else:
             ex = self._excinfo
             raise ex[1].with_traceback(ex[2])

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -1,18 +1,29 @@
 """
 Tracing utils
 """
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
+
+
+_Writer = Callable[[str], None]
+_Processor = Callable[[Tuple[str, ...], Tuple[Any, ...]], None]
 
 
 class TagTracer:
-    def __init__(self):
-        self._tags2proc = {}
-        self._writer = None
+    def __init__(self) -> None:
+        self._tags2proc: Dict[Tuple[str, ...], _Processor] = {}
+        self._writer: Optional[_Writer] = None
         self.indent = 0
 
-    def get(self, name):
+    def get(self, name: str) -> "TagTracerSub":
         return TagTracerSub(self, (name,))
 
-    def _format_message(self, tags, args):
+    def _format_message(self, tags: Sequence[str], args: Sequence[object]) -> str:
         if isinstance(args[-1], dict):
             extra = args[-1]
             args = args[:-1]
@@ -29,7 +40,7 @@ class TagTracer:
 
         return "".join(lines)
 
-    def _processmessage(self, tags, args):
+    def _processmessage(self, tags: Tuple[str, ...], args: Tuple[object, ...]) -> None:
         if self._writer is not None and args:
             self._writer(self._format_message(tags, args))
         try:
@@ -39,10 +50,12 @@ class TagTracer:
         else:
             processor(tags, args)
 
-    def setwriter(self, writer):
+    def setwriter(self, writer: _Writer) -> None:
         self._writer = writer
 
-    def setprocessor(self, tags, processor):
+    def setprocessor(
+        self, tags: Union[str, Tuple[str, ...]], processor: _Processor
+    ) -> None:
         if isinstance(tags, str):
             tags = tuple(tags.split(":"))
         else:
@@ -51,12 +64,12 @@ class TagTracer:
 
 
 class TagTracerSub:
-    def __init__(self, root, tags):
+    def __init__(self, root: TagTracer, tags: Tuple[str, ...]) -> None:
         self.root = root
         self.tags = tags
 
-    def __call__(self, *args):
+    def __call__(self, *args: object) -> None:
         self.root._processmessage(self.tags, args)
 
-    def get(self, name):
+    def get(self, name: str) -> "TagTracerSub":
         return self.__class__(self.root, self.tags + (name,))

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -70,22 +70,22 @@ def test_call_hook(benchmark, plugins, wrappers, nesting):
             yield
 
     class Plugin:
-        def __init__(self, num):
+        def __init__(self, num: int) -> None:
             self.num = num
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return f"<Plugin {self.num}>"
 
         @hookimpl
-        def fun(self, hooks, nesting: int):
+        def fun(self, hooks, nesting: int) -> None:
             if nesting:
                 hooks.fun(hooks=hooks, nesting=nesting - 1)
 
     class PluginWrap:
-        def __init__(self, num):
+        def __init__(self, num: int) -> None:
             self.num = num
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return f"<PluginWrap {self.num}>"
 
         @hookimpl(hookwrapper=True)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,18 +1,17 @@
 import pytest
+from pluggy import HookspecMarker, PluginManager
 
 
 @pytest.fixture(
     params=[lambda spec: spec, lambda spec: spec()],
     ids=["spec-is-class", "spec-is-instance"],
 )
-def he_pm(request, pm):
-    from pluggy import HookspecMarker
-
+def he_pm(request, pm: PluginManager) -> PluginManager:
     hookspec = HookspecMarker("example")
 
     class Hooks:
         @hookspec
-        def he_method1(self, arg):
+        def he_method1(self, arg: int) -> int:
             return arg + 1
 
     pm.add_hookspecs(request.param(Hooks))
@@ -20,7 +19,5 @@ def he_pm(request, pm):
 
 
 @pytest.fixture
-def pm():
-    from pluggy import PluginManager
-
+def pm() -> PluginManager:
     return PluginManager("example")

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -6,13 +6,13 @@ hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
 
 
-def test_parse_hookimpl_override():
+def test_parse_hookimpl_override() -> None:
     class MyPluginManager(PluginManager):
         def parse_hookimpl_opts(self, module_or_class, name):
             opts = PluginManager.parse_hookimpl_opts(self, module_or_class, name)
             if opts is None:
                 if name.startswith("x1"):
-                    opts = {}
+                    opts = {}  # type: ignore[assignment]
             return opts
 
     class Plugin:
@@ -44,7 +44,7 @@ def test_parse_hookimpl_override():
     assert pm.hook.x1meth2._wrappers[0].hookwrapper
 
 
-def test_warn_when_deprecated_specified(recwarn):
+def test_warn_when_deprecated_specified(recwarn) -> None:
     warning = DeprecationWarning("foo is deprecated")
 
     class Spec:
@@ -68,7 +68,7 @@ def test_warn_when_deprecated_specified(recwarn):
     assert record.lineno == Plugin.foo.__code__.co_firstlineno
 
 
-def test_plugin_getattr_raises_errors():
+def test_plugin_getattr_raises_errors() -> None:
     """Pluggy must be able to handle plugins which raise weird exceptions
     when getattr() gets called (#11).
     """
@@ -81,7 +81,7 @@ def test_plugin_getattr_raises_errors():
         pass
 
     module = Module()
-    module.x = DontTouchMe()
+    module.x = DontTouchMe()  # type: ignore[attr-defined]
 
     pm = PluginManager(hookspec.project_name)
     # register() would raise an error
@@ -89,7 +89,7 @@ def test_plugin_getattr_raises_errors():
     assert pm.get_plugin("donttouch") is module
 
 
-def test_warning_on_call_vs_hookspec_arg_mismatch():
+def test_warning_on_call_vs_hookspec_arg_mismatch() -> None:
     """Verify that is a hook is called with less arguments then defined in the
     spec that a warning is emitted.
     """
@@ -106,7 +106,7 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
 
     pm = PluginManager(hookspec.project_name)
     pm.register(Plugin())
-    pm.add_hookspecs(Spec())
+    pm.add_hookspecs(Spec)
 
     with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
@@ -114,13 +114,14 @@ def test_warning_on_call_vs_hookspec_arg_mismatch():
         # calling should trigger a warning
         pm.hook.myhook(arg1=1)
 
+        assert warns is not None
         assert len(warns) == 1
         warning = warns[-1]
         assert issubclass(warning.category, Warning)
         assert "Argument(s) ('arg2',)" in str(warning.message)
 
 
-def test_repr():
+def test_repr() -> None:
     class Plugin:
         @hookimpl
         def myhook(self):

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -2,16 +2,16 @@ from pluggy._hooks import varnames
 from pluggy._manager import _formatdef
 
 
-def test_varnames():
-    def f(x):
+def test_varnames() -> None:
+    def f(x) -> None:
         i = 3  # noqa
 
     class A:
-        def f(self, y):
+        def f(self, y) -> None:
             pass
 
     class B:
-        def __call__(self, z):
+        def __call__(self, z) -> None:
             pass
 
     assert varnames(f) == (("x",), ())
@@ -19,23 +19,23 @@ def test_varnames():
     assert varnames(B()) == (("z",), ())
 
 
-def test_varnames_default():
-    def f(x, y=3):
+def test_varnames_default() -> None:
+    def f(x, y=3) -> None:
         pass
 
     assert varnames(f) == (("x",), ("y",))
 
 
-def test_varnames_class():
+def test_varnames_class() -> None:
     class C:
-        def __init__(self, x):
+        def __init__(self, x) -> None:
             pass
 
     class D:
         pass
 
     class E:
-        def __init__(self, x):
+        def __init__(self, x) -> None:
             pass
 
     class F:
@@ -47,14 +47,14 @@ def test_varnames_class():
     assert varnames(F) == ((), ())
 
 
-def test_varnames_keyword_only():
-    def f1(x, *, y):
+def test_varnames_keyword_only() -> None:
+    def f1(x, *, y) -> None:
         pass
 
-    def f2(x, *, y=3):
+    def f2(x, *, y=3) -> None:
         pass
 
-    def f3(x=1, *, y=3):
+    def f3(x=1, *, y=3) -> None:
         pass
 
     assert varnames(f1) == (("x",), ())
@@ -62,7 +62,7 @@ def test_varnames_keyword_only():
     assert varnames(f3) == ((), ("x",))
 
 
-def test_formatdef():
+def test_formatdef() -> None:
     def function1():
         pass
 

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -1,87 +1,100 @@
-import pytest
+from typing import Callable, List, Sequence, TypeVar
 
-from pluggy import HookimplMarker, HookspecMarker, PluginValidationError
-from pluggy._hooks import HookImpl
+import pytest
+from pluggy import HookimplMarker, HookspecMarker, PluginManager, PluginValidationError
+from pluggy._hooks import HookImpl, _HookCaller
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
 
 
 @pytest.fixture
-def hc(pm):
+def hc(pm: PluginManager) -> _HookCaller:
     class Hooks:
         @hookspec
-        def he_method1(self, arg):
+        def he_method1(self, arg: object) -> None:
             pass
 
     pm.add_hookspecs(Hooks)
     return pm.hook.he_method1
 
 
-@pytest.fixture
-def addmeth(hc):
-    def addmeth(tryfirst=False, trylast=False, hookwrapper=False):
-        def wrap(func):
+FuncT = TypeVar("FuncT", bound=Callable[..., object])
+
+
+class AddMeth:
+    def __init__(self, hc: _HookCaller) -> None:
+        self.hc = hc
+
+    def __call__(
+        self, tryfirst: bool = False, trylast: bool = False, hookwrapper: bool = False
+    ) -> Callable[[FuncT], FuncT]:
+        def wrap(func: FuncT) -> FuncT:
             hookimpl(tryfirst=tryfirst, trylast=trylast, hookwrapper=hookwrapper)(func)
-            hc._add_hookimpl(HookImpl(None, "<temp>", func, func.example_impl))
+            self.hc._add_hookimpl(
+                HookImpl(None, "<temp>", func, func.example_impl),  # type: ignore[attr-defined]
+            )
             return func
 
         return wrap
 
-    return addmeth
+
+@pytest.fixture
+def addmeth(hc: _HookCaller) -> AddMeth:
+    return AddMeth(hc)
 
 
-def funcs(hookmethods):
+def funcs(hookmethods: Sequence[HookImpl]) -> List[Callable[..., object]]:
     return [hookmethod.function for hookmethod in hookmethods]
 
 
-def test_adding_nonwrappers(hc, addmeth):
+def test_adding_nonwrappers(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth()
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     @addmeth()
-    def he_method2():
+    def he_method2() -> None:
         pass
 
     @addmeth()
-    def he_method3():
+    def he_method3() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [he_method1, he_method2, he_method3]
 
 
-def test_adding_nonwrappers_trylast(hc, addmeth):
+def test_adding_nonwrappers_trylast(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth()
-    def he_method1_middle():
+    def he_method1_middle() -> None:
         pass
 
     @addmeth(trylast=True)
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     @addmeth()
-    def he_method1_b():
+    def he_method1_b() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [he_method1, he_method1_middle, he_method1_b]
 
 
-def test_adding_nonwrappers_trylast3(hc, addmeth):
+def test_adding_nonwrappers_trylast3(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth()
-    def he_method1_a():
+    def he_method1_a() -> None:
         pass
 
     @addmeth(trylast=True)
-    def he_method1_b():
+    def he_method1_b() -> None:
         pass
 
     @addmeth()
-    def he_method1_c():
+    def he_method1_c() -> None:
         pass
 
     @addmeth(trylast=True)
-    def he_method1_d():
+    def he_method1_d() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [
@@ -92,93 +105,96 @@ def test_adding_nonwrappers_trylast3(hc, addmeth):
     ]
 
 
-def test_adding_nonwrappers_trylast2(hc, addmeth):
+def test_adding_nonwrappers_trylast2(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth()
-    def he_method1_middle():
+    def he_method1_middle() -> None:
         pass
 
     @addmeth()
-    def he_method1_b():
+    def he_method1_b() -> None:
         pass
 
     @addmeth(trylast=True)
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [he_method1, he_method1_middle, he_method1_b]
 
 
-def test_adding_nonwrappers_tryfirst(hc, addmeth):
+def test_adding_nonwrappers_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth(tryfirst=True)
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     @addmeth()
-    def he_method1_middle():
+    def he_method1_middle() -> None:
         pass
 
     @addmeth()
-    def he_method1_b():
+    def he_method1_b() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [he_method1_middle, he_method1_b, he_method1]
 
 
-def test_adding_wrappers_ordering(hc, addmeth):
+def test_adding_wrappers_ordering(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth(hookwrapper=True)
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     @addmeth()
-    def he_method1_middle():
+    def he_method1_middle() -> None:
         pass
 
     @addmeth(hookwrapper=True)
-    def he_method3():
+    def he_method3() -> None:
         pass
 
     assert funcs(hc._nonwrappers) == [he_method1_middle]
     assert funcs(hc._wrappers) == [he_method1, he_method3]
 
 
-def test_adding_wrappers_ordering_tryfirst(hc, addmeth):
+def test_adding_wrappers_ordering_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth(hookwrapper=True, tryfirst=True)
-    def he_method1():
+    def he_method1() -> None:
         pass
 
     @addmeth(hookwrapper=True)
-    def he_method2():
+    def he_method2() -> None:
         pass
 
     assert hc._nonwrappers == []
     assert funcs(hc._wrappers) == [he_method2, he_method1]
 
 
-def test_hookspec(pm):
+def test_hookspec(pm: PluginManager) -> None:
     class HookSpec:
         @hookspec()
-        def he_myhook1(arg1):
+        def he_myhook1(arg1) -> None:
             pass
 
         @hookspec(firstresult=True)
-        def he_myhook2(arg1):
+        def he_myhook2(arg1) -> None:
             pass
 
         @hookspec(firstresult=False)
-        def he_myhook3(arg1):
+        def he_myhook3(arg1) -> None:
             pass
 
     pm.add_hookspecs(HookSpec)
+    assert pm.hook.he_myhook1.spec is not None
     assert not pm.hook.he_myhook1.spec.opts["firstresult"]
+    assert pm.hook.he_myhook2.spec is not None
     assert pm.hook.he_myhook2.spec.opts["firstresult"]
+    assert pm.hook.he_myhook3.spec is not None
     assert not pm.hook.he_myhook3.spec.opts["firstresult"]
 
 
 @pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])
 @pytest.mark.parametrize("val", [True, False])
-def test_hookimpl(name, val):
-    @hookimpl(**{name: val})
-    def he_myhook1(arg1):
+def test_hookimpl(name: str, val: bool) -> None:
+    @hookimpl(**{name: val})  # type: ignore[misc,call-overload]
+    def he_myhook1(arg1) -> None:
         pass
 
     if val:
@@ -187,13 +203,13 @@ def test_hookimpl(name, val):
         assert not hasattr(he_myhook1, name)
 
 
-def test_hookrelay_registry(pm):
+def test_hookrelay_registry(pm: PluginManager) -> None:
     """Verify hook caller instances are registered by name onto the relay
     and can be likewise unregistered."""
 
     class Api:
         @hookspec
-        def hello(self, arg):
+        def hello(self, arg: object) -> None:
             "api hook 1"
 
     pm.add_hookspecs(Api)
@@ -215,13 +231,13 @@ def test_hookrelay_registry(pm):
     assert hook.hello(arg=3) == []
 
 
-def test_hookrelay_registration_by_specname(pm):
+def test_hookrelay_registration_by_specname(pm: PluginManager) -> None:
     """Verify hook caller instances may also be registered by specifying a
     specname option to the hookimpl"""
 
     class Api:
         @hookspec
-        def hello(self, arg):
+        def hello(self, arg: object) -> None:
             "api hook 1"
 
     pm.add_hookspecs(Api)
@@ -231,7 +247,7 @@ def test_hookrelay_registration_by_specname(pm):
 
     class Plugin:
         @hookimpl(specname="hello")
-        def foo(self, arg):
+        def foo(self, arg: int) -> int:
             return arg + 1
 
     plugin = Plugin()
@@ -240,13 +256,13 @@ def test_hookrelay_registration_by_specname(pm):
     assert out == [4]
 
 
-def test_hookrelay_registration_by_specname_raises(pm):
+def test_hookrelay_registration_by_specname_raises(pm: PluginManager) -> None:
     """Verify using specname still raises the types of errors during registration as it
     would have without using specname."""
 
     class Api:
         @hookspec
-        def hello(self, arg):
+        def hello(self, arg: object) -> None:
             "api hook 1"
 
     pm.add_hookspecs(Api)
@@ -254,7 +270,7 @@ def test_hookrelay_registration_by_specname_raises(pm):
     # make sure a bad signature still raises an error when using specname
     class Plugin:
         @hookimpl(specname="hello")
-        def foo(self, arg, too, many, args):
+        def foo(self, arg: int, too, many, args) -> int:
             return arg + 1
 
     with pytest.raises(PluginValidationError):
@@ -264,7 +280,7 @@ def test_hookrelay_registration_by_specname_raises(pm):
     # corresponding spec.  EVEN if the function name matches one.
     class Plugin2:
         @hookimpl(specname="bar")
-        def hello(self, arg):
+        def hello(self, arg: int) -> int:
             return arg + 1
 
     pm.register(Plugin2())

--- a/testing/test_invocations.py
+++ b/testing/test_invocations.py
@@ -1,12 +1,12 @@
 import pytest
-from pluggy import PluginValidationError, HookimplMarker, HookspecMarker
+from pluggy import PluginManager, PluginValidationError, HookimplMarker, HookspecMarker
 
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
 
 
-def test_argmismatch(pm):
+def test_argmismatch(pm: PluginManager) -> None:
     class Api:
         @hookspec
         def hello(self, arg):
@@ -25,7 +25,7 @@ def test_argmismatch(pm):
     assert "argwrong" in str(exc.value)
 
 
-def test_only_kwargs(pm):
+def test_only_kwargs(pm: PluginManager) -> None:
     class Api:
         @hookspec
         def hello(self, arg):
@@ -39,7 +39,7 @@ def test_only_kwargs(pm):
     assert comprehensible in str(exc.value)
 
 
-def test_opt_in_args(pm):
+def test_opt_in_args(pm: PluginManager) -> None:
     """Verfiy that two hookimpls with mutex args can serve
     under the same spec.
     """
@@ -67,7 +67,7 @@ def test_opt_in_args(pm):
     assert results == [2, 1]
 
 
-def test_call_order(pm):
+def test_call_order(pm: PluginManager) -> None:
     class Api:
         @hookspec
         def hello(self, arg):
@@ -105,7 +105,7 @@ def test_call_order(pm):
     assert res == [3, 2, 1]
 
 
-def test_firstresult_definition(pm):
+def test_firstresult_definition(pm: PluginManager) -> None:
     class Api:
         @hookspec(firstresult=True)
         def hello(self, arg):
@@ -143,7 +143,7 @@ def test_firstresult_definition(pm):
     assert res == 2
 
 
-def test_firstresult_force_result(pm):
+def test_firstresult_force_result(pm: PluginManager) -> None:
     """Verify forcing a result in a wrapper."""
 
     class Api:
@@ -178,7 +178,7 @@ def test_firstresult_force_result(pm):
     assert res == 0  # this result is forced and not a list
 
 
-def test_firstresult_returns_none(pm):
+def test_firstresult_returns_none(pm: PluginManager) -> None:
     """If None results are returned by underlying implementations ensure
     the multi-call loop returns a None value.
     """
@@ -200,7 +200,7 @@ def test_firstresult_returns_none(pm):
     assert res is None
 
 
-def test_firstresult_no_plugin(pm):
+def test_firstresult_no_plugin(pm: PluginManager) -> None:
     """If no implementations/plugins have been registered for a firstresult
     hook the multi-call loop should return a None value.
     """

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -1,3 +1,5 @@
+from typing import Callable, Mapping, List, Sequence, Type, Union
+
 import pytest
 from pluggy import HookCallError, HookspecMarker, HookimplMarker
 from pluggy._hooks import HookImpl
@@ -8,16 +10,20 @@ hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")
 
 
-def MC(methods, kwargs, firstresult=False):
+def MC(
+    methods: Sequence[Callable[..., object]],
+    kwargs: Mapping[str, object],
+    firstresult: bool = False,
+) -> Union[object, List[object]]:
     caller = _multicall
     hookfuncs = []
     for method in methods:
-        f = HookImpl(None, "<temp>", method, method.example_impl)
+        f = HookImpl(None, "<temp>", method, method.example_impl)  # type: ignore[attr-defined]
         hookfuncs.append(f)
     return caller("foo", hookfuncs, kwargs, firstresult)
 
 
-def test_keyword_args():
+def test_keyword_args() -> None:
     @hookimpl
     def f(x):
         return x + 1
@@ -31,7 +37,7 @@ def test_keyword_args():
     assert reslist == [24 + 23, 24]
 
 
-def test_keyword_args_with_defaultargs():
+def test_keyword_args_with_defaultargs() -> None:
     @hookimpl
     def f(x, z=1):
         return x + z
@@ -40,7 +46,7 @@ def test_keyword_args_with_defaultargs():
     assert reslist == [24]
 
 
-def test_tags_call_error():
+def test_tags_call_error() -> None:
     @hookimpl
     def f(x):
         return x
@@ -49,7 +55,7 @@ def test_tags_call_error():
         MC([f], {})
 
 
-def test_call_none_is_no_result():
+def test_call_none_is_no_result() -> None:
     @hookimpl
     def m1():
         return 1
@@ -60,11 +66,11 @@ def test_call_none_is_no_result():
 
     res = MC([m1, m2], {}, firstresult=True)
     assert res == 1
-    res = MC([m1, m2], {}, {})
+    res = MC([m1, m2], {}, firstresult=False)
     assert res == [1]
 
 
-def test_hookwrapper():
+def test_hookwrapper() -> None:
     out = []
 
     @hookimpl(hookwrapper=True)
@@ -87,7 +93,7 @@ def test_hookwrapper():
     assert out == ["m1 init", "m2", "m1 finish"]
 
 
-def test_hookwrapper_order():
+def test_hookwrapper_order() -> None:
     out = []
 
     @hookimpl(hookwrapper=True)
@@ -107,7 +113,7 @@ def test_hookwrapper_order():
     assert out == ["m1 init", "m2 init", "m2 finish", "m1 finish"]
 
 
-def test_hookwrapper_not_yield():
+def test_hookwrapper_not_yield() -> None:
     @hookimpl(hookwrapper=True)
     def m1():
         pass
@@ -116,7 +122,7 @@ def test_hookwrapper_not_yield():
         MC([m1], {})
 
 
-def test_hookwrapper_too_many_yield():
+def test_hookwrapper_too_many_yield() -> None:
     @hookimpl(hookwrapper=True)
     def m1():
         yield 1
@@ -129,7 +135,7 @@ def test_hookwrapper_too_many_yield():
 
 
 @pytest.mark.parametrize("exc", [ValueError, SystemExit])
-def test_hookwrapper_exception(exc):
+def test_hookwrapper_exception(exc: "Type[BaseException]") -> None:
     out = []
 
     @hookimpl(hookwrapper=True)

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -2,16 +2,18 @@ from pluggy._tracing import TagTracer
 
 import pytest
 
+from typing import List
+
 
 @pytest.fixture
-def rootlogger():
+def rootlogger() -> TagTracer:
     return TagTracer()
 
 
-def test_simple(rootlogger):
+def test_simple(rootlogger: TagTracer) -> None:
     log = rootlogger.get("pytest")
     log("hello")
-    out = []
+    out: List[str] = []
     rootlogger.setwriter(out.append)
     log("world")
     assert len(out) == 1
@@ -21,7 +23,7 @@ def test_simple(rootlogger):
     assert out[1] == "hello [pytest:collection]\n"
 
 
-def test_indent(rootlogger):
+def test_indent(rootlogger: TagTracer) -> None:
     log = rootlogger.get("1")
     out = []
     log.root.setwriter(lambda arg: out.append(arg))
@@ -49,8 +51,7 @@ def test_indent(rootlogger):
     ]
 
 
-def test_readable_output_dictargs(rootlogger):
-
+def test_readable_output_dictargs(rootlogger: TagTracer) -> None:
     out = rootlogger._format_message(["test"], [1])
     assert out == "1 [test]\n"
 
@@ -58,7 +59,7 @@ def test_readable_output_dictargs(rootlogger):
     assert out2 == "test [test]\n    a: 1\n"
 
 
-def test_setprocessor(rootlogger):
+def test_setprocessor(rootlogger: TagTracer) -> None:
     log = rootlogger.get("1")
     log2 = log.get("2")
     assert log2.tags == tuple("12")


### PR DESCRIPTION
This adds type annotations to all pluggy code. This is a respin of #225 but now using Python 3 syntax.

The type annotations are not published, it will require some work for it to make sense, cleaning up the interface and imports and such. But I think internal type annotations are still useful for understand the code (I always have to relearn how stuff relate to each other when looking at pluggy) and as a linter.

In the meantime @RonnyPfannschmidt created #326. I think this PR is a better starting point because it almost doesn't change the code itself besides adding the types. Ronny's changes can be added on top maybe.