### PR TITLE
Remove HookSpec - inline into HookCaller

### DIFF
--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -182,12 +182,12 @@ def test_hookspec(pm: PluginManager) -> None:
             pass
 
     pm.add_hookspecs(HookSpec)
-    assert pm.hook.he_myhook1.spec is not None
-    assert not pm.hook.he_myhook1.spec.opts["firstresult"]
-    assert pm.hook.he_myhook2.spec is not None
-    assert pm.hook.he_myhook2.spec.opts["firstresult"]
-    assert pm.hook.he_myhook3.spec is not None
-    assert not pm.hook.he_myhook3.spec.opts["firstresult"]
+    assert pm.hook.he_myhook1.spec_opts is not None
+    assert not pm.hook.he_myhook1.spec_opts["firstresult"]
+    assert pm.hook.he_myhook2.spec_opts is not None
+    assert pm.hook.he_myhook2.spec_opts["firstresult"]
+    assert pm.hook.he_myhook3.spec_opts is not None
+    assert not pm.hook.he_myhook3.spec_opts["firstresult"]
 
 
 @pytest.mark.parametrize("name", ["hookwrapper", "optionalhook", "tryfirst", "trylast"])


### PR DESCRIPTION
In my opinion, the `HookSpec` type doesn't pull its weight -- it is closely tied in a one-to-one relation with `HookCaller` (possibly set after initialization), and can be reduced to two attributes (`spec_opts` and `spec_argnames`). So by inlining it into `HookCaller`, there's one less type to mentally keep track of.

The type is not public nor mentioned in the API Reference so removing it is not a breaking change.