### PR TITLE
Improve subset hook caller & related changes

### DIFF
--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -115,7 +115,6 @@ class PluginManager:
     def __init__(self, project_name: str) -> None:
         self.project_name: "Final" = project_name
         self._name2plugin: "Final[Dict[str, _Plugin]]" = {}
-        self._plugin2hookcallers: "Final[Dict[_Plugin, List[_HookCaller]]]" = {}
         self._plugin_distinfo: "Final[List[Tuple[_Plugin, DistFacade]]]" = []
         self.trace: "Final" = _tracing.TagTracer().get("pluginmanage")
         self.hook: "Final" = _HookRelay()
@@ -138,11 +137,17 @@ class PluginManager:
         is already registered."""
         plugin_name = name or self.get_canonical_name(plugin)
 
-        if plugin_name in self._name2plugin or plugin in self._plugin2hookcallers:
+        if plugin_name in self._name2plugin:
             if self._name2plugin.get(plugin_name, -1) is None:
                 return None  # blocked plugin, return None to indicate no registration
             raise ValueError(
-                "Plugin already registered: %s=%s\n%s"
+                "Plugin name already registered: %s=%s\n%s"
+                % (plugin_name, plugin, self._name2plugin)
+            )
+
+        if plugin in self._name2plugin.values():
+            raise ValueError(
+                "Plugin already registered under a different name: %s=%s\n%s"
                 % (plugin_name, plugin, self._name2plugin)
             )
 
@@ -151,8 +156,6 @@ class PluginManager:
         self._name2plugin[plugin_name] = plugin
 
         # register matching hook implementations of the plugin
-        hookcallers: List[_HookCaller] = []
-        self._plugin2hookcallers[plugin] = hookcallers
         for name in dir(plugin):
             hookimpl_opts = self.parse_hookimpl_opts(plugin, name)
             if hookimpl_opts is not None:
@@ -168,7 +171,6 @@ class PluginManager:
                     self._verify_hook(hook, hookimpl)
                     hook._maybe_apply_history(hookimpl)
                 hook._add_hookimpl(hookimpl)
-                hookcallers.append(hook)
         return plugin_name
 
     def parse_hookimpl_opts(
@@ -201,13 +203,15 @@ class PluginManager:
         if plugin is None:
             plugin = self.get_plugin(name)
 
+        hookcallers = self.get_hookcallers(plugin)
+        if hookcallers:
+            for hookcaller in hookcallers:
+                hookcaller._remove_plugin(plugin)
+
         # if self._name2plugin[name] == None registration was blocked: ignore
         if self._name2plugin.get(name):
             assert name is not None
             del self._name2plugin[name]
-
-        for hookcaller in self._plugin2hookcallers.pop(plugin, []):
-            hookcaller._remove_plugin(plugin)
 
         return plugin
 
@@ -254,11 +258,11 @@ class PluginManager:
 
     def get_plugins(self) -> Set[Any]:
         """return the set of registered plugins."""
-        return set(self._plugin2hookcallers)
+        return set(self._name2plugin.values())
 
     def is_registered(self, plugin: _Plugin) -> bool:
         """Return ``True`` if the plugin is already registered."""
-        return plugin in self._plugin2hookcallers
+        return any(plugin == val for val in self._name2plugin.values())
 
     def get_canonical_name(self, plugin: _Plugin) -> str:
         """Return canonical name for a plugin object. Note that a plugin
@@ -373,7 +377,14 @@ class PluginManager:
 
     def get_hookcallers(self, plugin: _Plugin) -> Optional[List[_HookCaller]]:
         """get all hook callers for the specified plugin."""
-        return self._plugin2hookcallers.get(plugin)
+        if self.get_name(plugin) is None:
+            return None
+        hookcallers = []
+        for hookcaller in self.hook.__dict__.values():
+            for hookimpl in hookcaller.get_hookimpls():
+                if hookimpl.plugin is plugin:
+                    hookcallers.append(hookcaller)
+        return hookcallers
 
     def add_hookcall_monitoring(
         self, before: _BeforeTrace, after: _AfterTrace

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -34,13 +34,18 @@ def test_parse_hookimpl_override() -> None:
     pm = MyPluginManager(hookspec.project_name)
     pm.register(Plugin())
     pm.add_hookspecs(Spec)
-    assert not pm.hook.x1meth._nonwrappers[0].hookwrapper
-    assert not pm.hook.x1meth._nonwrappers[0].tryfirst
-    assert not pm.hook.x1meth._nonwrappers[0].trylast
-    assert not pm.hook.x1meth._nonwrappers[0].optionalhook
 
-    assert pm.hook.x1meth2._wrappers[0].tryfirst
-    assert pm.hook.x1meth2._wrappers[0].hookwrapper
+    hookimpls = pm.hook.x1meth.get_hookimpls()
+    assert len(hookimpls) == 1
+    assert not hookimpls[0].hookwrapper
+    assert not hookimpls[0].tryfirst
+    assert not hookimpls[0].trylast
+    assert not hookimpls[0].optionalhook
+
+    hookimpls = pm.hook.x1meth2.get_hookimpls()
+    assert len(hookimpls) == 1
+    assert hookimpls[0].hookwrapper
+    assert hookimpls[0].tryfirst
 
 
 def test_warn_when_deprecated_specified(recwarn) -> None:
@@ -127,6 +132,6 @@ def test_repr() -> None:
 
     plugin = Plugin()
     pname = pm.register(plugin)
-    assert repr(pm.hook.myhook._nonwrappers[0]) == (
+    assert repr(pm.hook.myhook.get_hookimpls()[0]) == (
         f"<HookImpl plugin_name={pname!r}, plugin={plugin!r}>"
     )

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -61,7 +61,7 @@ def test_adding_nonwrappers(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method3() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [he_method1, he_method2, he_method3]
+    assert funcs(hc.get_hookimpls()) == [he_method1, he_method2, he_method3]
 
 
 def test_adding_nonwrappers_trylast(hc: _HookCaller, addmeth: AddMeth) -> None:
@@ -77,7 +77,7 @@ def test_adding_nonwrappers_trylast(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method1_b() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [he_method1, he_method1_middle, he_method1_b]
+    assert funcs(hc.get_hookimpls()) == [he_method1, he_method1_middle, he_method1_b]
 
 
 def test_adding_nonwrappers_trylast3(hc: _HookCaller, addmeth: AddMeth) -> None:
@@ -97,7 +97,7 @@ def test_adding_nonwrappers_trylast3(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method1_d() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [
+    assert funcs(hc.get_hookimpls()) == [
         he_method1_d,
         he_method1_b,
         he_method1_a,
@@ -118,7 +118,7 @@ def test_adding_nonwrappers_trylast2(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method1() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [he_method1, he_method1_middle, he_method1_b]
+    assert funcs(hc.get_hookimpls()) == [he_method1, he_method1_middle, he_method1_b]
 
 
 def test_adding_nonwrappers_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
@@ -134,7 +134,7 @@ def test_adding_nonwrappers_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method1_b() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [he_method1_middle, he_method1_b, he_method1]
+    assert funcs(hc.get_hookimpls()) == [he_method1_middle, he_method1_b, he_method1]
 
 
 def test_adding_wrappers_ordering(hc: _HookCaller, addmeth: AddMeth) -> None:
@@ -150,8 +150,11 @@ def test_adding_wrappers_ordering(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method3() -> None:
         pass
 
-    assert funcs(hc._nonwrappers) == [he_method1_middle]
-    assert funcs(hc._wrappers) == [he_method1, he_method3]
+    assert funcs(hc.get_hookimpls()) == [
+        he_method1_middle,
+        he_method1,
+        he_method3,
+    ]
 
 
 def test_adding_wrappers_ordering_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
@@ -163,8 +166,116 @@ def test_adding_wrappers_ordering_tryfirst(hc: _HookCaller, addmeth: AddMeth) ->
     def he_method2() -> None:
         pass
 
-    assert hc._nonwrappers == []
-    assert funcs(hc._wrappers) == [he_method2, he_method1]
+    assert funcs(hc.get_hookimpls()) == [he_method2, he_method1]
+
+
+def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
+    assert funcs(hc.get_hookimpls()) == []
+
+    @addmeth(hookwrapper=True, trylast=True)
+    def m1() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m1]
+
+    @addmeth()
+    def m2() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m2, m1]
+
+    @addmeth(trylast=True)
+    def m3() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m1]
+
+    @addmeth(hookwrapper=True)
+    def m4() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m1, m4]
+
+    @addmeth(hookwrapper=True, tryfirst=True)
+    def m5() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m1, m4, m5]
+
+    @addmeth(tryfirst=True)
+    def m6() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m6, m1, m4, m5]
+
+    @addmeth()
+    def m7() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m7, m6, m1, m4, m5]
+
+    @addmeth(hookwrapper=True)
+    def m8() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m3, m2, m7, m6, m1, m4, m8, m5]
+
+    @addmeth(trylast=True)
+    def m9() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m9, m3, m2, m7, m6, m1, m4, m8, m5]
+
+    @addmeth(tryfirst=True)
+    def m10() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m9, m3, m2, m7, m6, m10, m1, m4, m8, m5]
+
+    @addmeth(hookwrapper=True, trylast=True)
+    def m11() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [m9, m3, m2, m7, m6, m10, m11, m1, m4, m8, m5]
+
+    @addmeth(hookwrapper=True)
+    def m12() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [
+        m9,
+        m3,
+        m2,
+        m7,
+        m6,
+        m10,
+        m11,
+        m1,
+        m4,
+        m8,
+        m12,
+        m5,
+    ]
+
+    @addmeth()
+    def m13() -> None:
+        ...
+
+    assert funcs(hc.get_hookimpls()) == [
+        m9,
+        m3,
+        m2,
+        m7,
+        m13,
+        m6,
+        m10,
+        m11,
+        m1,
+        m4,
+        m8,
+        m12,
+        m5,
+    ]
 
 
 def test_hookspec(pm: PluginManager) -> None:

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -153,20 +153,25 @@ def test_register_hookwrapper_not_a_generator_function(he_pm: PluginManager) -> 
 
 def test_register(pm: PluginManager) -> None:
     class MyPlugin:
-        pass
+        @hookimpl
+        def he_method1(self):
+            ...
 
     my = MyPlugin()
     pm.register(my)
-    assert my in pm.get_plugins()
+    assert pm.get_plugins() == {my}
     my2 = MyPlugin()
     pm.register(my2)
-    assert {my, my2}.issubset(pm.get_plugins())
+    assert pm.get_plugins() == {my, my2}
 
     assert pm.is_registered(my)
     assert pm.is_registered(my2)
     pm.unregister(my)
     assert not pm.is_registered(my)
-    assert my not in pm.get_plugins()
+    assert pm.get_plugins() == {my2}
+
+    with pytest.raises(AssertionError, match=r"not registered"):
+        pm.unregister(my)
 
 
 def test_register_unknown_hooks(pm: PluginManager) -> None:
@@ -466,6 +471,58 @@ def test_get_hookimpls(pm: PluginManager) -> None:
     hookimpls = pm.hook.he_method1.get_hookimpls()
     hook_plugins = [item.plugin for item in hookimpls]
     assert hook_plugins == [plugin1, plugin2]
+
+
+def test_get_hookcallers(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec
+        def he_method1(self):
+            ...
+
+        @hookspec
+        def he_method2(self):
+            ...
+
+    pm.add_hookspecs(Hooks)
+
+    class Plugin1:
+        @hookimpl
+        def he_method1(self):
+            ...
+
+        @hookimpl
+        def he_method2(self):
+            ...
+
+    class Plugin2:
+        @hookimpl
+        def he_method1(self):
+            ...
+
+    class Plugin3:
+        @hookimpl
+        def he_method2(self):
+            ...
+
+    plugin1 = Plugin1()
+    pm.register(plugin1)
+    plugin2 = Plugin2()
+    pm.register(plugin2)
+    plugin3 = Plugin3()
+    pm.register(plugin3)
+
+    hookcallers1 = pm.get_hookcallers(plugin1)
+    assert hookcallers1 is not None
+    assert len(hookcallers1) == 2
+    hookcallers2 = pm.get_hookcallers(plugin2)
+    assert hookcallers2 is not None
+    assert len(hookcallers2) == 1
+    hookcallers3 = pm.get_hookcallers(plugin3)
+    assert hookcallers3 is not None
+    assert len(hookcallers3) == 1
+    assert hookcallers1 == hookcallers2 + hookcallers3
+
+    assert pm.get_hookcallers(object()) is None
 
 
 def test_add_hookspecs_nohooks(pm: PluginManager) -> None:


### PR DESCRIPTION
This PR contains 3 changes, which are (mostly) conceptually independent but better understood together.

The second commit fixes #346 and #347. The idea is, instead of creating a full-fledged HookCaller, create one which just proxies to the real HookCaller + the plugin filtering. The implementation is a bit hacky but the best I could come up after trying several approaches.

I ran the pytest testsuite and everything passes (after https://github.com/pytest-dev/pytest/pull/9512).

pluggy's benchmark suite looks good (not much difference, maybe a slight improvement). I still need to check pytest though, as pluggy's benchmark doesn't cover `subset_hook_caller` at all.

Please see the commits for details.