### PR TITLE
Proposed fix for issue #358

### DIFF
--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -244,8 +244,11 @@ def varnames(func: object) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
         except Exception:
             return (), ()
 
-    try:  # func MUST be a function or method here or we won't parse any args
-        sig = inspect.signature(func.__func__ if inspect.ismethod(func) else func)
+    try:
+        # func MUST be a function or method here or we won't parse any args.
+        sig = inspect.signature(
+            func.__func__ if inspect.ismethod(func) else func  # type:ignore[arg-type]
+        )
     except TypeError:
         return (), ()
 

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -245,11 +245,29 @@ def varnames(func: object) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
             return (), ()
 
     try:  # func MUST be a function or method here or we won't parse any args
-        spec = inspect.getfullargspec(func)
+        sig = inspect.signature(func.__func__ if inspect.ismethod(func) else func)
     except TypeError:
         return (), ()
 
-    args, defaults = tuple(spec.args), spec.defaults
+    _valid_param_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    _valid_params = {
+        name: param
+        for name, param in sig.parameters.items()
+        if param.kind in _valid_param_kinds
+    }
+    args = tuple(_valid_params)
+    defaults = (
+        tuple(
+            param.default
+            for param in _valid_params.values()
+            if param.default is not param.empty
+        )
+        or None
+    )
+
     if defaults:
         index = -len(defaults)
         args, kwargs = args[:index], tuple(args[index:])

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable
+from typing import Any, Callable, TypeVar, cast
 from pluggy._hooks import varnames
 from pluggy._manager import _formatdef
 
@@ -87,11 +87,13 @@ def test_formatdef() -> None:
 
 
 def test_varnames_decorator() -> None:
-    def my_decorator(func: Callable) -> Callable:
+    F = TypeVar('F', bound=Callable[..., Any])
+
+    def my_decorator(func: F) -> F:
         @wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
-        return wrapper
+        return cast(F, wrapper)
 
     @my_decorator
     def example(a, b=123) -> None:

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -1,3 +1,5 @@
+from functools import wraps
+from typing import Callable
 from pluggy._hooks import varnames
 from pluggy._manager import _formatdef
 
@@ -82,3 +84,17 @@ def test_formatdef() -> None:
         pass
 
     assert _formatdef(function4) == "function4(arg1, *args, **kwargs)"
+
+
+def test_varnames_decorator() -> None:
+    def my_decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+
+    @my_decorator
+    def example(a, b=123) -> None:
+        pass
+
+    assert varnames(example) == (("a",), ("b",))

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -87,12 +87,13 @@ def test_formatdef() -> None:
 
 
 def test_varnames_decorator() -> None:
-    F = TypeVar('F', bound=Callable[..., Any])
+    F = TypeVar("F", bound=Callable[..., Any])
 
     def my_decorator(func: F) -> F:
         @wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
+
         return cast(F, wrapper)
 
     @my_decorator

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -99,4 +99,13 @@ def test_varnames_decorator() -> None:
     def example(a, b=123) -> None:
         pass
 
+    class Example:
+        @my_decorator
+        def example_method(self, x, y=1) -> None:
+            pass
+
+    ex_inst = Example()
+
     assert varnames(example) == (("a",), ("b",))
+    assert varnames(Example.example_method) == (("x",), ("y",))
+    assert varnames(ex_inst.example_method) == (("x",), ("y",))


### PR DESCRIPTION
Switch to `inspect.signature` instead of `inspect.getfullargspec` to properly support wrapper chains (decorated functions) - see details in issue #358 .

In the proposed change I tried to do the minimal required changes to `varnames`.