### PR TITLE
Add support for Python 3.11 and drop EOL 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         name: [
           "windows-py36",
-          "windows-py310",
+          "windows-py311",
           "windows-pypy3",
 
           "ubuntu-py36",
@@ -29,6 +29,7 @@ jobs:
           "ubuntu-py38",
           "ubuntu-py39",
           "ubuntu-py310",
+          "ubuntu-py311",
           "ubuntu-pypy3",
           "ubuntu-benchmark",
 
@@ -41,12 +42,12 @@ jobs:
             python: "3.6"
             os: windows-latest
             tox_env: "py36"
-          - name: "windows-py310"
+          - name: "windows-py311"
             python: "3.10"
             os: windows-latest
-            tox_env: "py310"
+            tox_env: "py311"
           - name: "windows-pypy3"
-            python: "pypy3"
+            python: "pypy3.9"
             os: windows-latest
             tox_env: "pypy3"
           - name: "ubuntu-py36"
@@ -78,9 +79,13 @@ jobs:
             python: "3.10"
             os: ubuntu-latest
             tox_env: "py310"
+          - name: "ubuntu-py311"
+            python: "3.11"
+            os: ubuntu-latest
+            tox_env: "py311"
             use_coverage: true
           - name: "ubuntu-pypy3"
-            python: "pypy3"
+            python: "pypy3.9"
             os: ubuntu-latest
             tox_env: "pypy3"
             use_coverage: true
@@ -98,12 +103,12 @@ jobs:
             tox_env: "docs"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 
@@ -131,11 +136,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
@@ -148,7 +153,7 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         name: [
-          "windows-py36",
+          "windows-py37",
           "windows-py311",
           "windows-pypy3",
 
-          "ubuntu-py36",
           "ubuntu-py37-pytestmain",
           "ubuntu-py37",
           "ubuntu-py38",
@@ -38,10 +37,10 @@ jobs:
         ]
 
         include:
-          - name: "windows-py36"
-            python: "3.6"
+          - name: "windows-py37"
+            python: "3.7"
             os: windows-latest
-            tox_env: "py36"
+            tox_env: "py37"
           - name: "windows-py311"
             python: "3.10"
             os: windows-latest
@@ -50,11 +49,6 @@ jobs:
             python: "pypy3.9"
             os: windows-latest
             tox_env: "pypy3"
-          - name: "ubuntu-py36"
-            python: "3.6"
-            os: ubuntu-latest
-            tox_env: "py36"
-            use_coverage: true
           - name: "ubuntu-py37-pytestmain"
             python: "3.7"
             os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 21.7b0
+    rev: 22.10.0
     hooks:
     -   id: black
         args: [--safe, --quiet]
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.10.0
+    rev: v1.12.1
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.7b0]
+        additional_dependencies: [black==22.10.0]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
@@ -36,7 +36,7 @@ repos:
     hooks:
     -   id: rst-backticks
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.3
+    rev: v3.2.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,4 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]

--- a/changelog/364.feature.rst
+++ b/changelog/364.feature.rst
@@ -1,0 +1,1 @@
+Python 3.11 is now officially supported.

--- a/changelog/364.removal.rst
+++ b/changelog/364.removal.rst
@@ -1,0 +1,1 @@
+Python 3.6 is no longer supported.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ release = metadata.version(project)
 version = ".".join(release.split(".")[:2])
 
 
-language = None
+language = "en"
 
 pygments_style = "sphinx"
 # html_logo = "_static/img/plug.png"

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ packages =
     pluggy
 install_requires =
     importlib-metadata>=0.12;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir =
     =src
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=linting,docs,py{36,37,38,39,310,py3},py{36,37}-pytest{main}
+envlist=linting,docs,py{36,37,38,39,310,311,py3},py{36,37}-pytest{main}
 
 [testenv]
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=linting,docs,py{36,37,38,39,310,311,py3},py{36,37}-pytest{main}
+envlist=linting,docs,py{37,38,39,310,311,py3},py{37}-pytest{main}
 
 [testenv]
 commands=


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

And drop EOL Python 3.6.

Plus some other updates to fix the CI.