### PR TITLE
Add reorder-python-imports and autoflake hooks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
           "ubuntu-py311",
           "ubuntu-pypy3",
           "ubuntu-benchmark",
-
-          "linting",
-          "docs",
         ]
 
         include:
@@ -87,14 +84,6 @@ jobs:
             python: "3.8"
             os: ubuntu-latest
             tox_env: "benchmark"
-          - name: "linting"
-            python: "3.8"
-            os: ubuntu-latest
-            tox_env: "linting"
-          - name: "docs"
-            python: "3.8"
-            os: ubuntu-latest
-            tox_env: "docs"
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,33 @@
 repos:
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v1.7.7
+    hooks:
+    -   id: autoflake
+        name: autoflake
+        args: ["--in-place", "--remove-unused-variables", "--remove-all-unused-imports"]
+        language: python
+        files: \.py$
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.9.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py37-plus]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: flake8
+        additional_dependencies: [flake8-typing-imports]
+-   repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+    -   id: rst-backticks
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.2.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
@@ -9,20 +38,6 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==22.10.0]
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: flake8
-        additional_dependencies: [flake8-typing-imports]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.990
-    hooks:
-    -   id: mypy
-        files: ^(src/|testing/)
-        args: []
-        additional_dependencies: [pytest]
 -   repo: local
     hooks:
     -   id: rst
@@ -31,12 +46,10 @@ repos:
         files: ^(CHANGELOG.rst|HOWTORELEASE.rst|README.rst|changelog/.*)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.990
     hooks:
-    -   id: rst-backticks
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.2
-    hooks:
-    -   id: pyupgrade
-        args: [--py37-plus]
+    -   id: mypy
+        files: ^(src/|testing/)
+        args: []
+        additional_dependencies: [pytest]

--- a/docs/examples/eggsample/eggsample/host.py
+++ b/docs/examples/eggsample/eggsample/host.py
@@ -1,9 +1,10 @@
 import itertools
 import random
 
-import pluggy
+from eggsample import hookspecs
+from eggsample import lib
 
-from eggsample import hookspecs, lib
+import pluggy
 
 condiments_tray = {"pickled walnuts": 13, "steak sauce": 4, "mushy peas": 2}
 

--- a/docs/examples/eggsample/setup.py
+++ b/docs/examples/eggsample/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="eggsample",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -5,8 +5,10 @@ import argparse
 import sys
 from subprocess import check_call
 
-from colorama import init, Fore
-from git import Repo, Remote
+from colorama import Fore
+from colorama import init
+from git import Remote
+from git import Repo
 
 
 def create_branch(version):

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -2,10 +2,17 @@
 Call loop machinery
 """
 import sys
-from typing import cast, Generator, List, Mapping, Sequence, Union
+from typing import cast
+from typing import Generator
+from typing import List
+from typing import Mapping
+from typing import Sequence
 from typing import TYPE_CHECKING
+from typing import Union
 
-from ._result import HookCallError, _Result, _raise_wrapfail
+from ._result import _raise_wrapfail
+from ._result import _Result
+from ._result import HookCallError
 
 if TYPE_CHECKING:
     from ._hooks import HookImpl

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -5,21 +5,19 @@ import inspect
 import sys
 import warnings
 from types import ModuleType
-from typing import (
-    AbstractSet,
-    Any,
-    Callable,
-    Generator,
-    List,
-    Mapping,
-    Optional,
-    overload,
-    Sequence,
-    Tuple,
-    TypeVar,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import AbstractSet
+from typing import Any
+from typing import Callable
+from typing import Generator
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import overload
+from typing import Sequence
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import Union
 
 from ._result import _Result
 

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -2,36 +2,32 @@ import inspect
 import sys
 import types
 import warnings
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import Set
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import Union
 
 from . import _tracing
-from ._result import _Result
 from ._callers import _multicall
-from ._hooks import (
-    HookImpl,
-    HookSpec,
-    _HookCaller,
-    _SubsetHookCaller,
-    _HookImplFunction,
-    _HookRelay,
-    _Namespace,
-    normalize_hookimpl_opts,
-    _Plugin,
-)
+from ._hooks import _HookCaller
+from ._hooks import _HookImplFunction
+from ._hooks import _HookRelay
+from ._hooks import _Namespace
+from ._hooks import _Plugin
+from ._hooks import _SubsetHookCaller
+from ._hooks import HookImpl
+from ._hooks import HookSpec
+from ._hooks import normalize_hookimpl_opts
+from ._result import _Result
 
 if sys.version_info >= (3, 8):
     from importlib import metadata as importlib_metadata

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -3,17 +3,15 @@ Hook wrapper "result" utilities.
 """
 import sys
 from types import TracebackType
-from typing import (
-    Callable,
-    cast,
-    Generator,
-    Generic,
-    Optional,
-    Tuple,
-    Type,
-    TYPE_CHECKING,
-    TypeVar,
-)
+from typing import Callable
+from typing import cast
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
 if TYPE_CHECKING:
     from typing import NoReturn

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -2,9 +2,12 @@
 Benchmarking and performance tests.
 """
 import pytest
-from pluggy import HookspecMarker, HookimplMarker, PluginManager
-from pluggy._hooks import HookImpl
+
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import PluginManager
 from pluggy._callers import _multicall
+from pluggy._hooks import HookImpl
 
 
 hookspec = HookspecMarker("example")

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,5 +1,7 @@
 import pytest
-from pluggy import HookspecMarker, PluginManager
+
+from pluggy import HookspecMarker
+from pluggy import PluginManager
 
 
 @pytest.fixture(

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -1,5 +1,8 @@
 import pytest
-from pluggy import PluginManager, HookimplMarker, HookspecMarker
+
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import PluginManager
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -1,5 +1,9 @@
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import TypeVar
+
 from pluggy._hooks import varnames
 from pluggy._manager import _formatdef
 

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -1,8 +1,16 @@
-from typing import Callable, List, Sequence, TypeVar
+from typing import Callable
+from typing import List
+from typing import Sequence
+from typing import TypeVar
 
 import pytest
-from pluggy import HookimplMarker, HookspecMarker, PluginManager, PluginValidationError
-from pluggy._hooks import HookImpl, _HookCaller
+
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import PluginManager
+from pluggy import PluginValidationError
+from pluggy._hooks import _HookCaller
+from pluggy._hooks import HookImpl
 
 hookspec = HookspecMarker("example")
 hookimpl = HookimplMarker("example")

--- a/testing/test_invocations.py
+++ b/testing/test_invocations.py
@@ -1,5 +1,9 @@
 import pytest
-from pluggy import PluginManager, PluginValidationError, HookimplMarker, HookspecMarker
+
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import PluginManager
+from pluggy import PluginValidationError
 
 
 hookspec = HookspecMarker("example")

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -1,9 +1,17 @@
-from typing import Callable, Mapping, List, Sequence, Type, Union
+from typing import Callable
+from typing import List
+from typing import Mapping
+from typing import Sequence
+from typing import Type
+from typing import Union
 
 import pytest
-from pluggy import HookCallError, HookspecMarker, HookimplMarker
-from pluggy._hooks import HookImpl
+
+from pluggy import HookCallError
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
 from pluggy._callers import _multicall
+from pluggy._hooks import HookImpl
 
 
 hookspec = HookspecMarker("example")

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -1,17 +1,17 @@
 """
 ``PluginManager`` unit and public API testing.
 """
-import pytest
 import sys
-from typing import Any, List
+from typing import Any
+from typing import List
 
-from pluggy import (
-    HookCallError,
-    HookimplMarker,
-    HookspecMarker,
-    PluginManager,
-    PluginValidationError,
-)
+import pytest
+
+from pluggy import HookCallError
+from pluggy import HookimplMarker
+from pluggy import HookspecMarker
+from pluggy import PluginManager
+from pluggy import PluginValidationError
 
 if sys.version_info >= (3, 8):
     from importlib import metadata as importlib_metadata

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -1,8 +1,8 @@
-from pluggy._tracing import TagTracer
+from typing import List
 
 import pytest
 
-from typing import List
+from pluggy._tracing import TagTracer
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -20,12 +20,6 @@ deps=
   pytest
   pytest-benchmark
 
-[testenv:linting]
-skip_install = true
-basepython = python3
-deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
-
 [testenv:docs]
 deps =
   sphinx


### PR DESCRIPTION
Also:

- Change the order of the hooks, so those that change code but do not care about formatting run first, then black, and finally checkers like `mypy`.

- Drop `linting` environment: not needed anymore given we are using pre-commit.ci.
- Do not run `docs` on CI: we already use readthedocs.io for that (but keep tox environment for local execution).