### PR TITLE
Split CI workflows into 'test' and 'deploy'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+# Set permissions at the job level.
+permissions: {}
+
 jobs:
   package:
     name: Build & inspect our package.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
         with:
           attest-build-provenance-github: 'true'
 
@@ -32,11 +32,11 @@ jobs:
       id-token: write
     steps:
       - name: Download built packages from the check-package job.
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@v2
 
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: deploy
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  package:
+    name: Build & inspect our package.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  deploy:
+    needs: [package]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'pytest-dev/pluggy'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download built packages from the check-package job.
+        uses: actions/download-artifact@v8
+        with:
+          name: Packages
+          path: dist
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          attestations: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,17 @@ jobs:
   package:
     name: Build & inspect our package.
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          attest-build-provenance-github: 'true'
 
   deploy:
     needs: [package]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@v2
 
   test:
@@ -104,6 +105,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Download built packages from the check-package job.
       uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,12 +126,16 @@ jobs:
     - name: Test without coverage
       if: "! matrix.use_coverage"
       shell: bash
-      run: "tox run -e ${{ matrix.tox_env }}  --installpkg dist/*.whl"
+      run: "tox run --installpkg dist/*.whl"
+      env:
+        TOX_ENV: ${{ matrix.tox_env }}
 
     - name: Test with coverage
       if: "matrix.use_coverage"
       shell: bash
-      run: "tox run -e ${{ matrix.tox_env }}-coverage --installpkg dist/*.whl"
+      run: "tox run --installpkg dist/*.whl"
+      env:
+        TOX_ENV: ${{ matrix.tox_env }}-coverage
 
     - name: Upload coverage
       if: matrix.use_coverage && github.repository == 'pytest-dev/pluggy'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
     name: Build & inspect our package.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2.17.0
 
   test:
     needs: [check-package]
@@ -104,16 +104,16 @@ jobs:
             tox_env: "benchmark"
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Download built packages from the check-package job.
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: Packages
         path: dist
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python }}
         allow-prereleases: true
@@ -135,7 +135,7 @@ jobs:
 
     - name: Upload coverage
       if: matrix.use_coverage && github.repository == 'pytest-dev/pluggy'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       continue-on-error: true
       with:
         fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+# Set permissions at the job level.
+permissions: {}
+
 jobs:
   check-package:
     name: Build & inspect our package.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,10 @@
-name: main
+name: test
 
 on:
   push:
     branches:
       - main
       - test-me-*
-    tags:
-      - "*"
 
   pull_request:
     branches:
@@ -16,12 +14,12 @@ jobs:
   check-package:
     name: Build & inspect our package.
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@v2
+
   test:
     needs: [check-package]
     runs-on: ${{ matrix.os }}
@@ -137,20 +135,3 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.xml
         verbose: true
-
-  deploy:
-    needs: [check-package]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'pytest-dev/pluggy'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Download built packages from the check-package job.
-        uses: actions/download-artifact@v8
-        with:
-          name: Packages
-          path: dist
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          attestations: true

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Running this directly gets us::
 .. |versions| image:: https://img.shields.io/pypi/pyversions/pluggy.svg
     :target: https://pypi.org/pypi/pluggy
 
-.. |github-actions| image:: https://github.com/pytest-dev/pluggy/workflows/main/badge.svg
+.. |github-actions| image:: https://github.com/pytest-dev/pluggy/workflows/test/badge.svg
     :target: https://github.com/pytest-dev/pluggy/actions
 
 .. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/pluggy.svg
@@ -86,7 +86,7 @@ Running this directly gets us::
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 
-.. |codecov| image:: https://codecov.io/gh/pytest-dev/pluggy/branch/master/graph/badge.svg
+.. |codecov| image:: https://codecov.io/gh/pytest-dev/pluggy/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytest-dev/pluggy
     :alt: Code coverage Status
 


### PR DESCRIPTION
This makes them easier to maintain and follows how other pytest repositories have evolved.

Also made some changes to the deploy workflow:

* Using Python 3.10
* Using `build` package instead of calling `python setup.py`