### PR TITLE
Detailed error message on hook registration conflict

### DIFF
--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -337,7 +337,11 @@ class _HookCaller:
         specmodule_or_class: _Namespace,
         spec_opts: "_HookSpecOpts",
     ) -> None:
-        assert not self.has_spec()
+        if self.has_spec():
+            raise RuntimeError(
+                f"Hook {self.spec.name!r} is already registered "
+                f"within namespace {self.spec.namespace}"
+            )
         self.spec = HookSpec(specmodule_or_class, self.name, spec_opts)
         if spec_opts.get("historic"):
             self._call_history = []

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -338,7 +338,7 @@ class _HookCaller:
         spec_opts: "_HookSpecOpts",
     ) -> None:
         if self.spec is not None:
-            raise RuntimeError(
+            raise ValueError(
                 f"Hook {self.spec.name!r} is already registered "
                 f"within namespace {self.spec.namespace}"
             )

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -337,7 +337,7 @@ class _HookCaller:
         specmodule_or_class: _Namespace,
         spec_opts: "_HookSpecOpts",
     ) -> None:
-        if self.has_spec():
+        if self.spec is not None:
             raise RuntimeError(
                 f"Hook {self.spec.name!r} is already registered "
                 f"within namespace {self.spec.namespace}"

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -419,5 +419,9 @@ def test_hook_conflict(pm: PluginManager) -> None:
             pass
 
     pm.add_hookspecs(Api1)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError) as exc:
         pm.add_hookspecs(Api2)
+    assert str(exc.value) == (
+        "Hook 'conflict' is already registered within namespace "
+        "<class 'test_hookcaller.test_hook_conflict.<locals>.Api1'>"
+    )

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -405,3 +405,19 @@ def test_hookrelay_registration_by_specname_raises(pm: PluginManager) -> None:
     pm.register(Plugin2())
     with pytest.raises(PluginValidationError):
         pm.check_pending()
+
+
+def test_hook_conflict(pm: PluginManager) -> None:
+    class Api1:
+        @hookspec
+        def conflict(self) -> None:
+            pass
+
+    class Api2:
+        @hookspec
+        def conflict(self) -> None:
+            pass
+
+    pm.add_hookspecs(Api1)
+    with pytest.raises(RuntimeError):
+        pm.add_hookspecs(Api2)

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -411,12 +411,12 @@ def test_hook_conflict(pm: PluginManager) -> None:
     class Api1:
         @hookspec
         def conflict(self) -> None:
-            pass
+            """Api1 hook"""
 
     class Api2:
         @hookspec
         def conflict(self) -> None:
-            pass
+            """Api2 hook"""
 
     pm.add_hookspecs(Api1)
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
Hi! I've spent some time trying to nail down hook registration error:

```python
INTERNALERROR>     pluginmanager.add_hookspecs(Hookspec)
INTERNALERROR>   File "contrib/python/pluggy/py3/pluggy/_manager.py", line 175, in add_hookspecs
INTERNALERROR>     hc.set_specification(module_or_class, spec_opts)
INTERNALERROR>   File "contrib/python/pluggy/py3/pluggy/_hooks.py", line 200, in set_specification
INTERNALERROR>     assert not self.has_spec()
INTERNALERROR> AssertionError
```

This PR raises `RuntimeError` with detailed message which should ease developer's life a bit:

```python
E           RuntimeError: Hook 'conflict' is already registered within namespace <class 'test_hookcaller.test_hook_conflict.<locals>.Api1'>

src/pluggy/_hooks.py:341: RuntimeError
```