### PR TITLE
benchmark: fix benchmark running for only 1 round

### DIFF
--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -45,7 +45,7 @@ def test_hook_and_wrappers_speed(benchmark, hooks, wrappers):
         firstresult = False
         return (hook_name, hook_impls, caller_kwargs, firstresult), {}
 
-    benchmark.pedantic(_multicall, setup=setup)
+    benchmark.pedantic(_multicall, setup=setup, rounds=10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In d22672d954866276e04c8a6e4d3a4ba822604314 I didn't notice that using `pedantic` means the benchmark will only run for 1 round unless you tell it otherwise.