### PR TITLE
pyproject.toml: remove `wheel` build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
   "setuptools",
   "setuptools-scm",
-  "wheel",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
It is not needed.