### PR TITLE
result: use exception instead excinfo triplet

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -775,7 +775,7 @@ hook invocation point:
             outcome.get_result()
         except RuntimeError:
             # log the error details
-            print(outcome.excinfo)
+            print(outcome.exception)
 
 
     pm = PluginManager("myproject")

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -452,7 +452,7 @@ class PluginManager:
             methods: Sequence[HookImpl],
             kwargs: Mapping[str, object],
         ) -> None:
-            if outcome.excinfo is None:
+            if outcome.exception is None:
                 hooktrace("finish", hook_name, "-->", outcome.get_result())
             hooktrace.root.indent -= 1
 

--- a/testing/test_invocations.py
+++ b/testing/test_invocations.py
@@ -100,6 +100,8 @@ def test_call_order(pm: PluginManager) -> None:
             assert arg == 0
             outcome = yield
             assert outcome.get_result() == [3, 2, 1]
+            assert outcome.exception is None
+            assert outcome.excinfo is None
 
     pm.register(Plugin1())
     pm.register(Plugin2())

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -149,7 +149,9 @@ def test_hookwrapper_exception(exc: "Type[BaseException]") -> None:
     @hookimpl(hookwrapper=True)
     def m1():
         out.append("m1 init")
-        yield None
+        result = yield
+        assert isinstance(result.exception, exc)
+        assert result.excinfo[0] == exc
         out.append("m1 finish")
 
     @hookimpl


### PR DESCRIPTION
The excinfo triplet is a legacy concept, these days the exception instance itself carries the necessary info.

Switch the internal implementation to store just the exception instead of the triplet, and add an `exception` property to access it without the excinfo annoyance.