### PR TITLE
Hook wrapping without `_Result`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,6 +19,7 @@ exclude_lines =
     pragma: no cover
 
     if TYPE_CHECKING:
+    if False:
 
     if __name__ == .__main__.:
 

--- a/changelog/260.feature.rst
+++ b/changelog/260.feature.rst
@@ -1,0 +1,10 @@
+Add "new-style" hook wrappers, a simpler but equally powerful alternative to the existing ``hookwrapper=True`` wrappers.
+
+New-style wrappers are generator functions, similarly to ``hookwrapper``, but do away with the :class:`result <pluggy._callers._Result>` object.
+Instead, the return value is sent directly to the ``yield`` statement, or, if inner calls raised an exception, it is raised from the ``yield``.
+The wrapper is excepted to return a value or raise an exception, which will become the result of the hook call.
+
+New-style wrappers are fully interoperable with old-style wrappers.
+We encourage users to use the new style, however we do not intend to deprecate the old style any time soon.
+
+See :ref:`hookwrappers` for the full documentation.

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -290,10 +290,12 @@ class PluginManager:
         return None
 
     def _verify_hook(self, hook: _HookCaller, hookimpl: HookImpl) -> None:
-        if hook.is_historic() and hookimpl.hookwrapper:
+        if hook.is_historic() and (
+            hookimpl.hookwrapper or hookimpl.isgeneratorfunction
+        ):
             raise PluginValidationError(
                 hookimpl.plugin,
-                "Plugin %r\nhook %r\nhistoric incompatible to hookwrapper"
+                "Plugin %r\nhook %r\nhistoric incompatible with yield/hookwrapper"
                 % (hookimpl.plugin_name, hook.name),
             )
 

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -23,7 +23,10 @@ _T = TypeVar("_T")
 
 
 def _raise_wrapfail(
-    wrap_controller: Generator[None, _Result[_T], None], msg: str
+    wrap_controller: (
+        Generator[None, _Result[_T], None] | Generator[None, object, object]
+    ),
+    msg: str,
 ) -> NoReturn:
     co = wrap_controller.gi_code
     raise RuntimeError(

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -19,9 +19,9 @@ def hook(arg1, arg2, arg3):
     return arg1, arg2, arg3
 
 
-@hookimpl(hookwrapper=True)
+@hookimpl
 def wrapper(arg1, arg2, arg3):
-    yield
+    return (yield)
 
 
 @pytest.fixture(params=[10, 100], ids="hooks={}".format)
@@ -70,7 +70,7 @@ def test_call_hook(benchmark, plugins, wrappers, nesting):
     class HookSpec:
         @hookspec
         def fun(self, hooks, nesting: int):
-            yield
+            pass
 
     class Plugin:
         def __init__(self, num: int) -> None:
@@ -91,9 +91,9 @@ def test_call_hook(benchmark, plugins, wrappers, nesting):
         def __repr__(self) -> str:
             return f"<PluginWrap {self.num}>"
 
-        @hookimpl(hookwrapper=True)
+        @hookimpl
         def fun(self):
-            yield
+            return (yield)
 
     pm.add_hookspecs(HookSpec)
 

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -25,6 +25,10 @@ def test_parse_hookimpl_override() -> None:
         def x1meth2(self):
             yield  # pragma: no cover
 
+        @hookimpl(trylast=True)
+        def x1meth3(self):
+            return (yield)  # pragma: no cover
+
     class Spec:
         @hookspec
         def x1meth(self):
@@ -34,6 +38,10 @@ def test_parse_hookimpl_override() -> None:
         def x1meth2(self):
             pass
 
+        @hookspec
+        def x1meth3(self):
+            pass
+
     pm = MyPluginManager(hookspec.project_name)
     pm.register(Plugin())
     pm.add_hookspecs(Spec)
@@ -41,6 +49,7 @@ def test_parse_hookimpl_override() -> None:
     hookimpls = pm.hook.x1meth.get_hookimpls()
     assert len(hookimpls) == 1
     assert not hookimpls[0].hookwrapper
+    assert not hookimpls[0].isgeneratorfunction
     assert not hookimpls[0].tryfirst
     assert not hookimpls[0].trylast
     assert not hookimpls[0].optionalhook
@@ -48,7 +57,15 @@ def test_parse_hookimpl_override() -> None:
     hookimpls = pm.hook.x1meth2.get_hookimpls()
     assert len(hookimpls) == 1
     assert hookimpls[0].hookwrapper
+    assert hookimpls[0].isgeneratorfunction
     assert hookimpls[0].tryfirst
+
+    hookimpls = pm.hook.x1meth3.get_hookimpls()
+    assert len(hookimpls) == 1
+    assert not hookimpls[0].hookwrapper
+    assert hookimpls[0].isgeneratorfunction
+    assert not hookimpls[0].tryfirst
+    assert hookimpls[0].trylast
 
 
 def test_warn_when_deprecated_specified(recwarn) -> None:

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -147,42 +147,56 @@ def test_adding_nonwrappers_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
 
 def test_adding_wrappers_ordering(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth(hookwrapper=True)
-    def he_method1() -> None:
-        pass
+    def he_method1():
+        yield
 
     @addmeth()
-    def he_method1_middle() -> None:
-        pass
+    def he_method1_fun():
+        yield
+
+    @addmeth()
+    def he_method1_middle():
+        return
 
     @addmeth(hookwrapper=True)
-    def he_method3() -> None:
-        pass
+    def he_method3_fun():
+        yield
+
+    @addmeth(hookwrapper=True)
+    def he_method3():
+        yield
 
     assert funcs(hc.get_hookimpls()) == [
         he_method1_middle,
         he_method1,
+        he_method1_fun,
+        he_method3_fun,
         he_method3,
     ]
 
 
 def test_adding_wrappers_ordering_tryfirst(hc: _HookCaller, addmeth: AddMeth) -> None:
     @addmeth(hookwrapper=True, tryfirst=True)
-    def he_method1() -> None:
-        pass
+    def he_method1():
+        yield
 
     @addmeth(hookwrapper=True)
-    def he_method2() -> None:
-        pass
+    def he_method2():
+        yield
 
-    assert funcs(hc.get_hookimpls()) == [he_method2, he_method1]
+    @addmeth(tryfirst=True)
+    def he_method3():
+        yield
+
+    assert funcs(hc.get_hookimpls()) == [he_method2, he_method1, he_method3]
 
 
 def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
     assert funcs(hc.get_hookimpls()) == []
 
     @addmeth(hookwrapper=True, trylast=True)
-    def m1() -> None:
-        ...
+    def m1():
+        yield
 
     assert funcs(hc.get_hookimpls()) == [m1]
 
@@ -204,9 +218,9 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m1, m4]
 
-    @addmeth(hookwrapper=True, tryfirst=True)
-    def m5() -> None:
-        ...
+    @addmeth(tryfirst=True)
+    def m5():
+        yield
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m1, m4, m5]
 
@@ -222,9 +236,9 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m7, m6, m1, m4, m5]
 
-    @addmeth(hookwrapper=True)
-    def m8() -> None:
-        ...
+    @addmeth()
+    def m8():
+        yield
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m7, m6, m1, m4, m8, m5]
 
@@ -246,9 +260,9 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m9, m3, m2, m7, m6, m10, m11, m1, m4, m8, m5]
 
-    @addmeth(hookwrapper=True)
-    def m12() -> None:
-        ...
+    @addmeth()
+    def m12():
+        yield
 
     assert funcs(hc.get_hookimpls()) == [
         m9,

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -360,6 +360,23 @@ def test_register_historic_incompat_hookwrapper(pm: PluginManager) -> None:
         pm.register(Plugin())
 
 
+def test_register_historic_incompat_generator_fun(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec(historic=True)
+        def he_method1(self, arg):
+            pass
+
+    pm.add_hookspecs(Hooks)
+
+    class Plugin:
+        @hookimpl()
+        def he_method1(self, arg):
+            yield
+
+    with pytest.raises(PluginValidationError):
+        pm.register(Plugin())
+
+
 def test_call_extra(pm: PluginManager) -> None:
     class Hooks:
         @hookspec


### PR DESCRIPTION
This implements the idea from #260. I think it makes pluggy more elegant, and also provides a backward compatible fix for #244 (replaces #257).