### PR TITLE
pyproject.toml: add missing `build-backend` setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [build-system]
 requires = [
-  "setuptools",
-  "setuptools-scm",
+  # sync with setup.py until we discard non-pep-517/518
+  "setuptools>=45.0",
+  "setuptools-scm[toml]>=6.2.3",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/pluggy/_version.py"


### PR DESCRIPTION
Without it some legacy mode is used.