### PR TITLE
result: add `result.force_exception` API

### DIFF
--- a/changelog/394.feature.rst
+++ b/changelog/394.feature.rst
@@ -1,0 +1,5 @@
+Added the :meth:`~pluggy._callers._Result.force_exception` method to ``_Result``.
+
+``force_exception`` allows hookwrappers to force an exception or override/adjust an existing exception of a hook invocation,
+in a properly behaving manner. Using ``force_exception`` is preferred over raising an exception from the hookwrapper,
+because raising an exception causes other hookwrappers to be skipped.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -10,6 +10,7 @@ API Reference
 .. autoclass:: pluggy._callers._Result
 .. automethod:: pluggy._callers._Result.get_result
 .. automethod:: pluggy._callers._Result.force_result
+.. automethod:: pluggy._callers._Result.force_exception
 
 .. autoclass:: pluggy._hooks._HookCaller
 .. automethod:: pluggy._hooks._HookCaller.call_extra

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -75,9 +75,21 @@ class _Result(Generic[_T]):
         If the hook was marked as a ``firstresult`` a single value should
         be set, otherwise set a (modified) list of results. Any exceptions
         found during invocation will be deleted.
+
+        This overrides any previous result or exception.
         """
         self._result = result
         self._exception = None
+
+    def force_exception(self, exception: BaseException) -> None:
+        """Force the result to fail with ``exception``.
+
+        This overrides any previous result or exception.
+
+        .. versionadded:: 1.1.0
+        """
+        self._result = None
+        self._exception = exception
 
     def get_result(self) -> _T:
         """Get the result(s) for this hook call.


### PR DESCRIPTION
Hookwrappers do not currently provide a public, proper way to override or force an exception. Raising directly from the hookwrapper causes further wrappers to be skipped, but this is not something we want to change at this point, for fear of breaking things, and because we are adding a replacement. See #244 on this issue.