### PR TITLE
manager: remove `__slots__` from `PluginManager`

### DIFF
--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -92,16 +92,6 @@ class PluginManager:
     which will subsequently send debug information to the trace helper.
     """
 
-    __slots__ = (
-        "project_name",
-        "_name2plugin",
-        "_plugin2hookcallers",
-        "_plugin_distinfo",
-        "trace",
-        "hook",
-        "_inner_hookexec",
-    )
-
     def __init__(self, project_name: str) -> None:
         self.project_name: Final = project_name
         self._name2plugin: Final[dict[str, _Plugin]] = {}


### PR DESCRIPTION
Added in 0b45952cf9f8fece53a5efd1cf40466b5714c17f. Broke two downstream projects:

- devpi: https://github.com/devpi/devpi/issues/980
- A test in tox which mocks something in PluginManager.

It is not worth it.