### PR TITLE
hooks: remove a couple of unnecessary slots from `_SubsetHookCaller`

### DIFF
--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -507,8 +507,6 @@ class _SubsetHookCaller(_HookCaller):
     __slots__ = (
         "_orig",
         "_remove_plugins",
-        "name",
-        "_hookexec",
     )
 
     def __init__(self, orig: _HookCaller, remove_plugins: AbstractSet[_Plugin]) -> None:


### PR DESCRIPTION
They are specified in the base class, it's wrong to specify in the subclass.