### PR TITLE
Make new-style wrappers use explicit `wrapper=True`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,5 +23,7 @@ exclude_lines =
 
     if __name__ == .__main__.:
 
+    raise NotImplementedError
+
     # Ignore coverage on lines solely with `...`
     ^\s*\.\.\.\s*$

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,9 @@ pluggy 1.1.0 (YANKED)
 
 .. note::
 
-  This release was yanked because unfortunately the new-style hook wrappers broke some downstream projects. See `#403 <https://github.com/pytest-dev/pluggy/issues/403>`__ for more information.
+  This release was yanked because unfortunately the implicit new-style hook wrappers broke some downstream projects.
+  See `#403 <https://github.com/pytest-dev/pluggy/issues/403>`__ for more information.
+  This was rectified in the 1.2.0 release.
 
 Deprecations and Removals
 -------------------------

--- a/changelog/405.feature.rst
+++ b/changelog/405.feature.rst
@@ -1,0 +1,1 @@
+The new-style hook wrappers, added in the yanked 1.1.0 release, now require an explicit ``wrapper=True`` designation in the ``@hookimpl()`` decorator.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -366,19 +366,25 @@ Wrappers
 .. note::
     This section describes "new-style hook wrappers", which were added in Pluggy
     1.1. For earlier versions, see the "old-style hook wrappers" section below.
-    The two styles are fully interoperable.
 
-A *hookimpl* can be a generator function, which indicates that the function will
-be called to *wrap* (or surround) all other normal *hookimpl* calls. A *hook
-wrapper* can thus execute some code ahead and after the execution of all
-corresponding non-wrappper *hookimpls*.
+    New-style hooks wrappers are declared with ``wrapper=True``, while
+    old-style hook wrappers are declared with ``hookwrapper=True``.
+
+    The two styles are fully interoperable between plugins using different
+    styles. However within the same plugin we recommend using only one style,
+    for consistency.
+
+A *hookimpl* can be marked with the ``"wrapper"`` option, which indicates
+that the function will be called to *wrap* (or surround) all other normal
+*hookimpl* calls. A *hook wrapper* can thus execute some code ahead and after the
+execution of all corresponding non-wrappper *hookimpls*.
 
 Much in the same way as a :py:func:`@contextlib.contextmanager <python:contextlib.contextmanager>`,
 *hook wrappers* must be implemented as generator function with a single ``yield`` in its body:
 
 .. code-block:: python
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def setup_project(config, args):
         """Wrap calls to ``setup_project()`` implementations which
         should return json encoded config options.
@@ -837,7 +843,7 @@ re-raised at the hook invocation point:
             return 3
 
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def myhook(self, args):
         try:
             return (yield)

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -66,7 +66,7 @@ def _multicall(
                         teardowns.append((wrapper_gen,))
                     except StopIteration:
                         _raise_wrapfail(wrapper_gen, "did not yield")
-                elif hook_impl.isgeneratorfunction:
+                elif hook_impl.wrapper:
                     try:
                         # If this cast is not valid, a type error is raised below,
                         # which is the desired response.

--- a/testing/benchmark.py
+++ b/testing/benchmark.py
@@ -19,7 +19,7 @@ def hook(arg1, arg2, arg3):
     return arg1, arg2, arg3
 
 
-@hookimpl
+@hookimpl(wrapper=True)
 def wrapper(arg1, arg2, arg3):
     return (yield)
 
@@ -91,7 +91,7 @@ def test_call_hook(benchmark, plugins, wrappers, nesting):
         def __repr__(self) -> str:
             return f"<PluginWrap {self.num}>"
 
-        @hookimpl
+        @hookimpl(wrapper=True)
         def fun(self):
             return (yield)
 

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -25,7 +25,7 @@ def test_parse_hookimpl_override() -> None:
         def x1meth2(self):
             yield  # pragma: no cover
 
-        @hookimpl(trylast=True)
+        @hookimpl(wrapper=True, trylast=True)
         def x1meth3(self):
             return (yield)  # pragma: no cover
 
@@ -49,7 +49,7 @@ def test_parse_hookimpl_override() -> None:
     hookimpls = pm.hook.x1meth.get_hookimpls()
     assert len(hookimpls) == 1
     assert not hookimpls[0].hookwrapper
-    assert not hookimpls[0].isgeneratorfunction
+    assert not hookimpls[0].wrapper
     assert not hookimpls[0].tryfirst
     assert not hookimpls[0].trylast
     assert not hookimpls[0].optionalhook
@@ -57,13 +57,13 @@ def test_parse_hookimpl_override() -> None:
     hookimpls = pm.hook.x1meth2.get_hookimpls()
     assert len(hookimpls) == 1
     assert hookimpls[0].hookwrapper
-    assert hookimpls[0].isgeneratorfunction
+    assert not hookimpls[0].wrapper
     assert hookimpls[0].tryfirst
 
     hookimpls = pm.hook.x1meth3.get_hookimpls()
     assert len(hookimpls) == 1
     assert not hookimpls[0].hookwrapper
-    assert hookimpls[0].isgeneratorfunction
+    assert hookimpls[0].wrapper
     assert not hookimpls[0].tryfirst
     assert hookimpls[0].trylast
 

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -35,10 +35,19 @@ class AddMeth:
         self.hc = hc
 
     def __call__(
-        self, tryfirst: bool = False, trylast: bool = False, hookwrapper: bool = False
+        self,
+        tryfirst: bool = False,
+        trylast: bool = False,
+        hookwrapper: bool = False,
+        wrapper: bool = False,
     ) -> Callable[[FuncT], FuncT]:
         def wrap(func: FuncT) -> FuncT:
-            hookimpl(tryfirst=tryfirst, trylast=trylast, hookwrapper=hookwrapper)(func)
+            hookimpl(
+                tryfirst=tryfirst,
+                trylast=trylast,
+                hookwrapper=hookwrapper,
+                wrapper=wrapper,
+            )(func)
             self.hc._add_hookimpl(
                 HookImpl(None, "<temp>", func, func.example_impl),  # type: ignore[attr-defined]
             )
@@ -150,7 +159,7 @@ def test_adding_wrappers_ordering(hc: _HookCaller, addmeth: AddMeth) -> None:
     def he_method1():
         yield
 
-    @addmeth()
+    @addmeth(wrapper=True)
     def he_method1_fun():
         yield
 
@@ -184,7 +193,7 @@ def test_adding_wrappers_ordering_tryfirst(hc: _HookCaller, addmeth: AddMeth) ->
     def he_method2():
         yield
 
-    @addmeth(tryfirst=True)
+    @addmeth(wrapper=True, tryfirst=True)
     def he_method3():
         yield
 
@@ -218,7 +227,7 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m1, m4]
 
-    @addmeth(tryfirst=True)
+    @addmeth(wrapper=True, tryfirst=True)
     def m5():
         yield
 
@@ -236,7 +245,7 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m3, m2, m7, m6, m1, m4, m5]
 
-    @addmeth()
+    @addmeth(wrapper=True)
     def m8():
         yield
 
@@ -260,7 +269,7 @@ def test_adding_wrappers_complex(hc: _HookCaller, addmeth: AddMeth) -> None:
 
     assert funcs(hc.get_hookimpls()) == [m9, m3, m2, m7, m6, m10, m11, m1, m4, m8, m5]
 
-    @addmeth()
+    @addmeth(wrapper=True)
     def m12():
         yield
 

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -111,10 +111,10 @@ def test_hookwrapper_two_yields() -> None:
         MC([m], {})
 
 
-def test_generator_fun() -> None:
+def test_wrapper() -> None:
     out = []
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m1():
         out.append("m1 init")
         result = yield
@@ -135,8 +135,8 @@ def test_generator_fun() -> None:
     assert out == ["m1 init", "m2", "m1 finish"]
 
 
-def test_generator_fun_two_yields() -> None:
-    @hookimpl
+def test_wrapper_two_yields() -> None:
+    @hookimpl(wrapper=True)
     def m():
         yield
         yield
@@ -154,7 +154,7 @@ def test_hookwrapper_order() -> None:
         yield 1
         out.append("m1 finish")
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m2():
         out.append("m2 init")
         result = yield 2
@@ -218,8 +218,8 @@ def test_hookwrapper_too_many_yield() -> None:
     assert (__file__ + ":") in str(ex.value)
 
 
-def test_generator_fun_yield_not_executed() -> None:
-    @hookimpl
+def test_wrapper_yield_not_executed() -> None:
+    @hookimpl(wrapper=True)
     def m1():
         if False:
             yield  # type: ignore[unreachable]
@@ -228,10 +228,10 @@ def test_generator_fun_yield_not_executed() -> None:
         MC([m1], {})
 
 
-def test_generator_fun_too_many_yield() -> None:
+def test_wrapper_too_many_yield() -> None:
     out = []
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m1():
         try:
             yield 1
@@ -320,10 +320,10 @@ def test_hookwrapper_force_exception() -> None:
 
 
 @pytest.mark.parametrize("exc", [ValueError, SystemExit])
-def test_generator_fun_exception(exc: "Type[BaseException]") -> None:
+def test_wrapper_exception(exc: "Type[BaseException]") -> None:
     out = []
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m1():
         out.append("m1 init")
         try:
@@ -345,24 +345,24 @@ def test_generator_fun_exception(exc: "Type[BaseException]") -> None:
     assert out == ["m1 init", "m2 init", "m1 finish"]
 
 
-def test_generator_fun_exception_chaining() -> None:
+def test_wrapper_exception_chaining() -> None:
     @hookimpl
     def m1():
         raise Exception("m1")
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m2():
         try:
             yield
         except Exception:
             raise Exception("m2")
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m3():
         yield
         return 10
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m4():
         try:
             yield
@@ -381,7 +381,7 @@ def test_generator_fun_exception_chaining() -> None:
 def test_unwind_inner_wrapper_teardown_exc() -> None:
     out = []
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m1():
         out.append("m1 init")
         try:
@@ -393,7 +393,7 @@ def test_unwind_inner_wrapper_teardown_exc() -> None:
         finally:
             out.append("m1 cleanup")
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m2():
         out.append("m2 init")
         yield
@@ -419,14 +419,14 @@ def test_unwind_inner_wrapper_teardown_exc() -> None:
 def test_suppress_inner_wrapper_teardown_exc() -> None:
     out = []
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m1():
         out.append("m1 init")
         result = yield
         out.append("m1 finish")
         return result
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m2():
         out.append("m2 init")
         try:
@@ -436,7 +436,7 @@ def test_suppress_inner_wrapper_teardown_exc() -> None:
             out.append("m2 suppress")
             return 22
 
-    @hookimpl
+    @hookimpl(wrapper=True)
     def m3():
         out.append("m3 init")
         yield

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -156,6 +156,21 @@ def test_register_hookwrapper_not_a_generator_function(he_pm: PluginManager) -> 
     assert excinfo.value.plugin is plugin
 
 
+def test_register_both_wrapper_and_hookwrapper(he_pm: PluginManager) -> None:
+    class hello:
+        @hookimpl(wrapper=True, hookwrapper=True)
+        def he_method1(self):
+            yield  # pragma: no cover
+
+    plugin = hello()
+
+    with pytest.raises(
+        PluginValidationError, match="wrapper.*hookwrapper.*mutually exclusive"
+    ) as excinfo:
+        he_pm.register(plugin)
+    assert excinfo.value.plugin is plugin
+
+
 def test_register(pm: PluginManager) -> None:
     class MyPlugin:
         @hookimpl
@@ -360,7 +375,7 @@ def test_register_historic_incompat_hookwrapper(pm: PluginManager) -> None:
         pm.register(Plugin())
 
 
-def test_register_historic_incompat_generator_fun(pm: PluginManager) -> None:
+def test_register_historic_incompat_wrapper(pm: PluginManager) -> None:
     class Hooks:
         @hookspec(historic=True)
         def he_method1(self, arg):
@@ -369,7 +384,7 @@ def test_register_historic_incompat_generator_fun(pm: PluginManager) -> None:
     pm.add_hookspecs(Hooks)
 
     class Plugin:
-        @hookimpl()
+        @hookimpl(wrapper=True)
         def he_method1(self, arg):
             yield
 


### PR DESCRIPTION
Previously new-style wrappers were implied by the function being a generator, however that broke a use case of a non-wrapper impl being a generator as a way to return an Iterator result. This is legitimate, and used at least by conda (see #403).

Therefore, change to require an explicit `wrapper=True`. Also adds a test for the iterator-returning case.

Fix #405.