### PR TITLE
ci: test with pytest-main branch on py3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=linting,docs,py{37,38,39,310,311,py3},py{37}-pytest{main}
+envlist=linting,docs,py{37,38,39,310,311,py3},py{38}-pytest{main}
 
 [testenv]
 commands=


### PR DESCRIPTION
Reason: `pytest` dropped py3.7 support in https://github.com/pytest-dev/pytest/pull/11152. This PR adjust the CI to test with pytest-main on py3.8 instead.