### PR TITLE
ensure the type hints support the writer unsetting in tagtracer

### DIFF
--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -49,7 +49,7 @@ class TagTracer:
         else:
             processor(tags, args)
 
-    def setwriter(self, writer: _Writer) -> None:
+    def setwriter(self, writer: _Writer | None) -> None:
         self._writer = writer
 
     def setprocessor(self, tags: str | tuple[str, ...], processor: _Processor) -> None:


### PR DESCRIPTION
Reason: `pytest` uses `TagTracer.setwriter(None)` when unsetting the tracer in https://github.com/pytest-dev/pytest/blob/1de0923e83e3258709559d86d142adaab65a42d8/src/_pytest/helpconfig.py#L126. This PR adjusts the typing of `TagTracer.setwriter` to support this case.