### PR TITLE
Export pluggy's typing

### DIFF
--- a/changelog/428.feature.rst
+++ b/changelog/428.feature.rst
@@ -1,0 +1,18 @@
+Pluggy now exposes its typings to static type checkers.
+
+As part of this, the following changes are made:
+
+- Renamed ``_Result`` to ``Result``, and exported as :class:`pluggy.Result`.
+- Renamed ``_HookRelay`` to ``HookRelay``, and exported as :class:`pluggy.HookRelay`.
+- Renamed ``_HookCaller`` to ``HookCaller``, and exported as :class:`pluggy.HookCaller`.
+- Exported ``HookImpl`` as :class:`pluggy.HookImpl`.
+- Renamed ``_HookImplOpts`` to ``HookimplOpts``, and exported as :class:`pluggy.HookimplOpts`.
+- Renamed ``_HookSpecOpts`` to ``HookspecOpts``, and exported as :class:`pluggy.HookspecOpts`.
+- Some fields and classes are marked ``Final`` and ``@final``.
+- The :ref:`api-reference` is updated to clearly delineate pluggy's public API.
+
+Compatibility aliases are put in place for the renamed types.
+We do not plan to remove the aliases, but we strongly recommend to only import from ``pluggy.*`` to ensure future compatibility.
+
+Please note that pluggy is currently unable to provide strong typing for hook calls, e.g. ``pm.hook.my_hook(...)``,
+nor to statically check that a hook implementation matches the hook specification's type.

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _`api-reference`:
+
 API Reference
 =============
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,8 @@ dev =
 testing =
     pytest
     pytest-benchmark
+[options.package_data]
+pluggy = py.typed
 
 [devpi:upload]
 formats=sdist.tgz,bdist_wheel

--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -6,6 +6,7 @@ except ImportError:
     __version__ = "unknown"
 
 __all__ = [
+    "__version__",
     "PluginManager",
     "PluginValidationError",
     "HookCaller",

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -9,8 +9,8 @@ from typing import Sequence
 from typing import Tuple
 
 
-_Writer = Callable[[str], None]
-_Processor = Callable[[Tuple[str, ...], Tuple[Any, ...]], None]
+_Writer = Callable[[str], object]
+_Processor = Callable[[Tuple[str, ...], Tuple[Any, ...]], object]
 
 
 class TagTracer:


### PR DESCRIPTION
This exports our typing, fixing #428.

I ran pytest mypy against this (see https://github.com/pytest-dev/pytest/pull/11353), which required a couple of fixes in pluggy - see first 2 commits. Other than that, should be good.