### PR TITLE
faster baseline import

### DIFF
--- a/src/pluggy/__init__.py
+++ b/src/pluggy/__init__.py
@@ -17,10 +17,8 @@ __all__ = [
 from ._hooks import HookCaller
 from ._hooks import HookImpl
 from ._hooks import HookimplMarker
-from ._hooks import HookimplOpts
 from ._hooks import HookRelay
 from ._hooks import HookspecMarker
-from ._hooks import HookspecOpts
 from ._manager import PluginManager
 from ._manager import PluginValidationError
 from ._result import HookCallError
@@ -28,3 +26,17 @@ from ._result import Result
 from ._version import version as __version__
 from ._warnings import PluggyTeardownRaisedWarning
 from ._warnings import PluggyWarning
+
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from ._types import HookimplOpts
+    from ._types import HookspecOpts
+else:
+
+    def __getattr__(name: str) -> object:
+        if name.endswith("Opts"):
+            from . import _types
+
+            return getattr(_types, name)
+        raise AttributeError(name)

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -14,13 +14,11 @@ from ._warnings import PluggyTeardownRaisedWarning
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from collections.abc import Mapping
+    from collections.abc import Sequence
     from typing import cast
-    from typing import Generator
-    from typing import Mapping
     from typing import NoReturn
-    from typing import Sequence
-    from typing import Tuple
-    from typing import Union
 
 # Need to distinguish between old- and new-style hook wrappers.
 # Wrapping with a tuple is the fastest type-safe way I found to do it.

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -117,7 +117,7 @@ def _multicall(
                         # If this cast is not valid, a type error is raised below,
                         # which is the desired response.
                         res = hook_impl.function(*args)
-                        function_gen = cast(Generator[None, object, object], res)
+                        function_gen = cast("Generator[None, object, object]", res)
                         next(function_gen)  # first yield
                         teardowns.append(function_gen)
                     except StopIteration:

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -4,17 +4,22 @@ Call loop machinery
 
 from __future__ import annotations
 
-from collections.abc import Generator
-from collections.abc import Mapping
-from collections.abc import Sequence
-from typing import cast
-from typing import NoReturn
 import warnings
 
 from ._hooks import HookImpl
+from ._result import _raise_wrapfail
 from ._result import HookCallError
 from ._result import Result
-from ._warnings import PluggyTeardownRaisedWarning
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import cast
+    from typing import Generator
+    from typing import Mapping
+    from typing import NoReturn
+    from typing import Sequence
+    from typing import Tuple
+    from typing import Union
 
 
 # Need to distinguish between old- and new-style hook wrappers.

--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 import warnings
 
 from ._hooks import HookImpl
-from ._result import _raise_wrapfail
 from ._result import HookCallError
 from ._result import Result
+from ._warnings import PluggyTeardownRaisedWarning
+
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -20,7 +21,6 @@ if TYPE_CHECKING:
     from typing import Sequence
     from typing import Tuple
     from typing import Union
-
 
 # Need to distinguish between old- and new-style hook wrappers.
 # Wrapping with a tuple is the fastest type-safe way I found to do it.

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -11,6 +11,7 @@ from collections.abc import Set
 import sys
 import warnings
 
+
 _Plugin = object
 
 TYPE_CHECKING = False
@@ -386,6 +387,7 @@ class HookRelay:
         def __getattr__(self, name: str) -> HookCaller: ...
 
     _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
+
 
 # Historical name (pluggy<=1.2), kept for backward compatibility.
 _HookRelay = HookRelay

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
 
     from ._result import Result
 
-
     _T = TypeVar("_T")
     _F = TypeVar("_F", bound=Callable[..., object])
     _Namespace = Union[ModuleType, type]
@@ -45,7 +44,6 @@ if TYPE_CHECKING:
     ]
     _HookImplFunction = Callable[..., Union[_T, Generator[None, Result[_T], None]]]
     _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
-
 
     class HookspecOpts(TypedDict):
         """Options for a hook specification."""
@@ -61,7 +59,6 @@ if TYPE_CHECKING:
         #:
         #: .. versionadded:: 1.5
         warn_on_impl_args: Mapping[str, Warning] | None
-
 
     class HookimplOpts(TypedDict):
         """Options for a hook implementation."""
@@ -84,11 +81,11 @@ if TYPE_CHECKING:
         specname: str | None
 
 else:
+
     def final(func: _F) -> _F:
         return func
+
     overload = final
-
-
 
 
 @final
@@ -388,6 +385,7 @@ class HookRelay:
 
         def __getattr__(self, name: str) -> HookCaller: ...
 
+    _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
 
 # Historical name (pluggy<=1.2), kept for backward compatibility.
 _HookRelay = HookRelay

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -16,18 +16,17 @@ _Plugin = object
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from collections.abc import Mapping
+    from collections.abc import Sequence
     from types import ModuleType
-    from typing import AbstractSet
     from typing import Any
     from typing import Callable
     from typing import Final
     from typing import final
-    from typing import Generator
     from typing import List
-    from typing import Mapping
     from typing import Optional
     from typing import overload
-    from typing import Sequence
     from typing import Tuple
     from typing import TYPE_CHECKING
     from typing import TypeVar
@@ -43,7 +42,7 @@ if TYPE_CHECKING:
         Union[object, list[object]],
     ]
     _HookImplFunction = Callable[..., Union[_T, Generator[None, Result[_T], None]]]
-    _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
+    _CallHistory = list[tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
 
     from ._types import HookimplOpts
     from ._types import HookspecOpts

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -8,70 +8,87 @@ from collections.abc import Generator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from collections.abc import Set
-import inspect
 import sys
-from types import ModuleType
-from typing import Any
-from typing import Callable
-from typing import Final
-from typing import final
-from typing import Optional
-from typing import overload
-from typing import TYPE_CHECKING
-from typing import TypedDict
-from typing import TypeVar
-from typing import Union
 import warnings
 
-from ._result import Result
-
-
-_T = TypeVar("_T")
-_F = TypeVar("_F", bound=Callable[..., object])
-_Namespace = Union[ModuleType, type]
 _Plugin = object
-_HookExec = Callable[
-    [str, Sequence["HookImpl"], Mapping[str, object], bool],
-    Union[object, list[object]],
-]
-_HookImplFunction = Callable[..., Union[_T, Generator[None, Result[_T], None]]]
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import AbstractSet
+    from typing import Any
+    from typing import Callable
+    from typing import Final
+    from typing import final
+    from typing import Generator
+    from typing import List
+    from typing import Mapping
+    from typing import Optional
+    from typing import overload
+    from typing import Sequence
+    from typing import Tuple
+    from typing import TYPE_CHECKING
+    from typing import TypedDict
+    from typing import TypeVar
+    from typing import Union
+
+    from ._result import Result
 
 
-class HookspecOpts(TypedDict):
-    """Options for a hook specification."""
-
-    #: Whether the hook is :ref:`first result only <firstresult>`.
-    firstresult: bool
-    #: Whether the hook is :ref:`historic <historic>`.
-    historic: bool
-    #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
-    warn_on_impl: Warning | None
-    #: Whether the hook warns when :ref:`certain arguments are requested
-    #: <warn_on_impl>`.
-    #:
-    #: .. versionadded:: 1.5
-    warn_on_impl_args: Mapping[str, Warning] | None
+    _T = TypeVar("_T")
+    _F = TypeVar("_F", bound=Callable[..., object])
+    _Namespace = Union[ModuleType, type]
+    _HookExec = Callable[
+        [str, Sequence["HookImpl"], Mapping[str, object], bool],
+        Union[object, list[object]],
+    ]
+    _HookImplFunction = Callable[..., Union[_T, Generator[None, Result[_T], None]]]
+    _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
 
 
-class HookimplOpts(TypedDict):
-    """Options for a hook implementation."""
+    class HookspecOpts(TypedDict):
+        """Options for a hook specification."""
 
-    #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
-    wrapper: bool
-    #: Whether the hook implementation is an :ref:`old-style wrapper
-    #: <old_style_hookwrappers>`.
-    hookwrapper: bool
-    #: Whether validation against a hook specification is :ref:`optional
-    #: <optionalhook>`.
-    optionalhook: bool
-    #: Whether to try to order this hook implementation :ref:`first
-    #: <callorder>`.
-    tryfirst: bool
-    #: Whether to try to order this hook implementation :ref:`last
-    #: <callorder>`.
-    trylast: bool
-    #: The name of the hook specification to match, see :ref:`specname`.
-    specname: str | None
+        #: Whether the hook is :ref:`first result only <firstresult>`.
+        firstresult: bool
+        #: Whether the hook is :ref:`historic <historic>`.
+        historic: bool
+        #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
+        warn_on_impl: Warning | None
+        #: Whether the hook warns when :ref:`certain arguments are requested
+        #: <warn_on_impl>`.
+        #:
+        #: .. versionadded:: 1.5
+        warn_on_impl_args: Mapping[str, Warning] | None
+
+
+    class HookimplOpts(TypedDict):
+        """Options for a hook implementation."""
+
+        #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
+        wrapper: bool
+        #: Whether the hook implementation is an :ref:`old-style wrapper
+        #: <old_style_hookwrappers>`.
+        hookwrapper: bool
+        #: Whether validation against a hook specification is :ref:`optional
+        #: <optionalhook>`.
+        optionalhook: bool
+        #: Whether to try to order this hook implementation :ref:`first
+        #: <callorder>`.
+        tryfirst: bool
+        #: Whether to try to order this hook implementation :ref:`last
+        #: <callorder>`.
+        trylast: bool
+        #: The name of the hook specification to match, see :ref:`specname`.
+        specname: str | None
+
+else:
+    def final(func: _F) -> _F:
+        return func
+    overload = final
+
+
 
 
 @final
@@ -297,6 +314,8 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     In case of a class, its ``__init__`` method is considered.
     For methods the ``self`` parameter is not included.
     """
+    import inspect
+
     if inspect.isclass(func):
         try:
             func = func.__init__

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from typing import Sequence
     from typing import Tuple
     from typing import TYPE_CHECKING
-    from typing import TypedDict
     from typing import TypeVar
     from typing import Union
 
@@ -46,41 +45,8 @@ if TYPE_CHECKING:
     _HookImplFunction = Callable[..., Union[_T, Generator[None, Result[_T], None]]]
     _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
 
-    class HookspecOpts(TypedDict):
-        """Options for a hook specification."""
-
-        #: Whether the hook is :ref:`first result only <firstresult>`.
-        firstresult: bool
-        #: Whether the hook is :ref:`historic <historic>`.
-        historic: bool
-        #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
-        warn_on_impl: Warning | None
-        #: Whether the hook warns when :ref:`certain arguments are requested
-        #: <warn_on_impl>`.
-        #:
-        #: .. versionadded:: 1.5
-        warn_on_impl_args: Mapping[str, Warning] | None
-
-    class HookimplOpts(TypedDict):
-        """Options for a hook implementation."""
-
-        #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
-        wrapper: bool
-        #: Whether the hook implementation is an :ref:`old-style wrapper
-        #: <old_style_hookwrappers>`.
-        hookwrapper: bool
-        #: Whether validation against a hook specification is :ref:`optional
-        #: <optionalhook>`.
-        optionalhook: bool
-        #: Whether to try to order this hook implementation :ref:`first
-        #: <callorder>`.
-        tryfirst: bool
-        #: Whether to try to order this hook implementation :ref:`last
-        #: <callorder>`.
-        trylast: bool
-        #: The name of the hook specification to match, see :ref:`specname`.
-        specname: str | None
-
+    from ._types import HookimplOpts
+    from ._types import HookspecOpts
 else:
 
     def final(func: _F) -> _F:
@@ -385,8 +351,6 @@ class HookRelay:
     if TYPE_CHECKING:
 
         def __getattr__(self, name: str) -> HookCaller: ...
-
-    _CallHistory = List[Tuple[Mapping[str, object], Optional[Callable[[Any], None]]]]
 
 
 # Historical name (pluggy<=1.2), kept for backward compatibility.

--- a/src/pluggy/_importlib_metadata.py
+++ b/src/pluggy/_importlib_metadata.py
@@ -1,0 +1,68 @@
+"""this module contains importlib_metadata usage and importing
+
+it's deferred to avoid import-time dependency on importlib_metadata
+
+.. code-block:: console
+
+   python -X importtime -c 'import pluggy' 2> import0.log
+   tuna import0.log
+
+
+"""
+from __future__ import annotations
+
+import importlib.metadata
+from typing import Any
+
+from . import _manager
+
+
+class DistFacade:
+    """Emulate a pkg_resources Distribution"""
+
+    def __init__(self, dist: importlib.metadata.Distribution) -> None:
+        self._dist = dist
+
+    @property
+    def project_name(self) -> str:
+        name: str = self.metadata["name"]
+        return name
+
+    def __getattr__(self, attr: str, default: object | None = None) -> Any:
+        return getattr(self._dist, attr, default)
+
+    def __dir__(self) -> list[str]:
+        return sorted(dir(self._dist) + ["_dist", "project_name"])
+
+
+def load_importlib_entrypoints(
+    manager: _manager.PluginManager,
+    group: str,
+    name: str | None = None,
+) -> int:
+    """Load modules from querying the specified setuptools ``group``.
+
+    :param group:
+        Entry point group to load plugins.
+    :param name:
+        If given, loads only plugins with the given ``name``.
+
+    :return:
+        The number of plugins loaded by this call.
+    """
+    count = 0
+    for dist in list(importlib.metadata.distributions()):
+        for ep in dist.entry_points:
+            if (
+                ep.group != group
+                or (name is not None and ep.name != name)
+                # already registered
+                or manager.get_plugin(ep.name)
+                or manager.is_blocked(ep.name)
+            ):
+                continue
+            plugin = ep.load()
+            manager.register(plugin, name=ep.name)
+            manager._plugin_dist_metadata.append((plugin, dist))
+            count += 1
+    return count

--- a/src/pluggy/_importlib_metadata.py
+++ b/src/pluggy/_importlib_metadata.py
@@ -9,6 +9,7 @@ it's deferred to avoid import-time dependency on importlib_metadata
 
 
 """
+
 from __future__ import annotations
 
 import importlib.metadata

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -29,12 +29,7 @@ from ._result import Result
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from ._hooks import HookimplOpts
-    from ._hooks import HookspecOpts
-
-    from ._hooks import _HookImplFunction
-    from ._hooks import _Namespace
-
+    from importlib.metadata import Distribution
     from typing import Any
     from typing import Callable
     from typing import Final
@@ -42,7 +37,11 @@ if TYPE_CHECKING:
     from typing import Mapping
     from typing import Sequence
     from typing import TypeAlias
-    from importlib.metadata import Distribution
+
+    from ._hooks import _HookImplFunction
+    from ._hooks import _Namespace
+    from ._hooks import HookimplOpts
+    from ._hooks import HookspecOpts
     from ._importlib_metadata import DistFacade
 
 _BeforeTrace: TypeAlias = "Callable[[str, Sequence[HookImpl], Mapping[str, Any]], None]"

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+<<<<<<< HEAD
 from collections.abc import Iterable
 from collections.abc import Mapping
 from collections.abc import Sequence
@@ -10,33 +11,49 @@ from typing import Callable
 from typing import cast
 from typing import Final
 from typing import TYPE_CHECKING
+=======
+import types
+>>>>>>> 24f5da0 (cleanups)
 import warnings
 
 from . import _tracing
 from ._callers import _multicall
-from ._hooks import _HookImplFunction
-from ._hooks import _Namespace
 from ._hooks import _Plugin
 from ._hooks import _SubsetHookCaller
 from ._hooks import HookCaller
 from ._hooks import HookImpl
-from ._hooks import HookimplOpts
 from ._hooks import HookRelay
-from ._hooks import HookspecOpts
 from ._hooks import normalize_hookimpl_opts
 from ._result import Result
 
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
-    # importtlib.metadata import is slow, defer it.
-    import importlib.metadata
+    from ._hooks import HookimplOpts
+    from ._hooks import HookspecOpts
 
+    from ._hooks import _HookImplFunction
+    from ._hooks import _Namespace
 
-_BeforeTrace = Callable[[str, Sequence[HookImpl], Mapping[str, Any]], None]
-_AfterTrace = Callable[[Result[Any], str, Sequence[HookImpl], Mapping[str, Any]], None]
+    from typing import Any
+    from typing import Callable
+    from typing import Final
+    from typing import Iterable
+    from typing import Mapping
+    from typing import Sequence
+    from typing import TypeAlias
+    from importlib.metadata import Distribution
+    from ._importlib_metadata import DistFacade
+
+_BeforeTrace: TypeAlias = "Callable[[str, Sequence[HookImpl], Mapping[str, Any]], None]"
+_AfterTrace: TypeAlias = (
+    "Callable[[Result[Any], str, Sequence[HookImpl], Mapping[str, Any]], None]"
+)
 
 
 def _warn_for_function(warning: Warning, function: Callable[..., object]) -> None:
+    from typing import cast
+
     func = cast(types.FunctionType, function)
     warnings.warn_explicit(
         warning,
@@ -57,24 +74,6 @@ class PluginValidationError(Exception):
         super().__init__(message)
         #: The plugin which failed validation.
         self.plugin = plugin
-
-
-class DistFacade:
-    """Emulate a pkg_resources Distribution"""
-
-    def __init__(self, dist: importlib.metadata.Distribution) -> None:
-        self._dist = dist
-
-    @property
-    def project_name(self) -> str:
-        name: str = self.metadata["name"]
-        return name
-
-    def __getattr__(self, attr: str, default: Any | None = None) -> Any:
-        return getattr(self._dist, attr, default)
-
-    def __dir__(self) -> list[str]:
-        return sorted(dir(self._dist) + ["_dist", "project_name"])
 
 
 class PluginManager:
@@ -98,7 +97,7 @@ class PluginManager:
         #: The project name.
         self.project_name: Final = project_name
         self._name2plugin: Final[dict[str, _Plugin]] = {}
-        self._plugin_distinfo: Final[list[tuple[_Plugin, DistFacade]]] = []
+        self._plugin_dist_metadata: Final[list[tuple[_Plugin, Distribution]]] = []
         #: The "hook relay", used to call a hook on all registered plugins.
         #: See :ref:`calling`.
         self.hook: Final = HookRelay()
@@ -182,6 +181,8 @@ class PluginManager:
         options for items decorated with :class:`HookimplMarker`.
         """
         method: object = getattr(plugin, name)
+        import inspect
+
         if not inspect.isroutine(method):
             return None
         try:
@@ -347,6 +348,7 @@ class PluginManager:
                 f"Argument(s) {notinspec} are declared in the hookimpl but "
                 "can not be found in the hookspec",
             )
+        import inspect
 
         if hook.spec.warn_on_impl_args:
             for hookimpl_argname in hookimpl.argnames:
@@ -390,7 +392,11 @@ class PluginManager:
                         )
 
     def load_setuptools_entrypoints(self, group: str, name: str | None = None) -> int:
-        """Load modules from querying the specified setuptools ``group``.
+        """legacy alias for load_importlib_entrypoints"""
+        return self.load_importlib_entrypoints(group, name)
+
+    def load_importlib_entrypoints(self, group: str, name: str | None = None) -> int:
+        """Load modules for the given importlib_metadata entrypoint ``group``.
 
         :param group:
             Entry point group to load plugins.
@@ -400,29 +406,25 @@ class PluginManager:
         :return:
             The number of plugins loaded by this call.
         """
-        import importlib.metadata
+        from ._importlib_metadata import load_importlib_entrypoints
 
-        count = 0
-        for dist in list(importlib.metadata.distributions()):
-            for ep in dist.entry_points:
-                if (
-                    ep.group != group
-                    or (name is not None and ep.name != name)
-                    # already registered
-                    or self.get_plugin(ep.name)
-                    or self.is_blocked(ep.name)
-                ):
-                    continue
-                plugin = ep.load()
-                self.register(plugin, name=ep.name)
-                self._plugin_distinfo.append((plugin, DistFacade(dist)))
-                count += 1
-        return count
+        return load_importlib_entrypoints(self, group, name)
 
     def list_plugin_distinfo(self) -> list[tuple[_Plugin, DistFacade]]:
         """Return a list of (plugin, distinfo) pairs for all
-        setuptools-registered plugins."""
-        return list(self._plugin_distinfo)
+        setuptools-registered plugins.
+
+        (soft deprecated)
+        """
+        from ._importlib_metadata import DistFacade
+
+        return [
+            (plugin, DistFacade(metadata))
+            for plugin, metadata in self._plugin_dist_metadata
+        ]
+
+    def list_plugin_distributions(self) -> list[tuple[_Plugin, Distribution]]:
+        return self._plugin_dist_metadata[:]
 
     def list_name_plugin(self) -> list[tuple[str, _Plugin]]:
         """Return a list of (name, plugin) pairs for all registered plugins."""
@@ -520,4 +522,6 @@ class PluginManager:
 
 
 def _formatdef(func: Callable[..., object]) -> str:
+    import inspect
+
     return f"{func.__name__}{inspect.signature(func)}"

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
 
     from ._hooks import _HookImplFunction
     from ._hooks import _Namespace
-    from ._hooks import HookimplOpts
-    from ._hooks import HookspecOpts
     from ._importlib_metadata import DistFacade
+    from ._types import HookimplOpts
+    from ._types import HookspecOpts
 
 _BeforeTrace: TypeAlias = "Callable[[str, Sequence[HookImpl], Mapping[str, Any]], None]"
 _AfterTrace: TypeAlias = (

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Type
     from typing import TypeVar
 
-    _ExcInfo = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
+    _ExcInfo = tuple[type[BaseException], BaseException, Optional[TracebackType]]
     ResultType = TypeVar("ResultType")
 else:
     from ._hooks import final

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -4,14 +4,14 @@ Hook wrapper "result" utilities.
 
 from __future__ import annotations
 
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from types import TracebackType
     from typing import Callable
     from typing import cast
     from typing import final
-    from typing import  Generic
-
+    from typing import Generic
     from typing import Optional
     from typing import Tuple
     from typing import Type

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -3,6 +3,7 @@ Hook wrapper "result" utilities.
 """
 
 from __future__ import annotations
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from types import TracebackType
@@ -16,16 +17,20 @@ if TYPE_CHECKING:
     from typing import Type
     from typing import TypeVar
 
-
     _ExcInfo = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
     ResultType = TypeVar("ResultType")
 else:
     from ._hooks import final
 
+    def cast(v, t):
+        return t
+
     class Generic:
         """fake generic"""
-        def __class_getitem__(cls, key)-> type[object]:
+
+        def __class_getitem__(cls, key) -> type[object]:
             return object
+
     ResultType = "ResultType"
 
 
@@ -110,7 +115,7 @@ class Result(Generic[ResultType]):
         exc = self._exception
         tb = self._traceback
         if exc is None:
-            return cast(ResultType, self._result)
+            return cast("ResultType", self._result)
         else:
             raise exc.with_traceback(tb)
 

--- a/src/pluggy/_result.py
+++ b/src/pluggy/_result.py
@@ -3,18 +3,30 @@ Hook wrapper "result" utilities.
 """
 
 from __future__ import annotations
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from types import TracebackType
+    from typing import Callable
+    from typing import cast
+    from typing import final
+    from typing import  Generic
 
-from types import TracebackType
-from typing import Callable
-from typing import cast
-from typing import final
-from typing import Generic
-from typing import Optional
-from typing import TypeVar
+    from typing import Optional
+    from typing import Tuple
+    from typing import Type
+    from typing import TypeVar
 
 
-_ExcInfo = tuple[type[BaseException], BaseException, Optional[TracebackType]]
-ResultType = TypeVar("ResultType")
+    _ExcInfo = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
+    ResultType = TypeVar("ResultType")
+else:
+    from ._hooks import final
+
+    class Generic:
+        """fake generic"""
+        def __class_getitem__(cls, key)-> type[object]:
+            return object
+    ResultType = "ResultType"
 
 
 class HookCallError(Exception):

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -4,13 +4,13 @@ Tracing utils
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
-from typing import Callable
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Sequence, TypeAlias, Callable, Any, Tuple
 
 
-_Writer = Callable[[str], object]
-_Processor = Callable[[tuple[str, ...], tuple[Any, ...]], object]
+_Writer: TypeAlias = "Callable[[str], object]"
+_Processor: TypeAlias = "Callable[[Tuple[str, ...], Tuple[Any, ...]], object]"
 
 
 class TagTracer:

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import Any
     from typing import Callable
-    from typing import Sequence
     from typing import Tuple
     from typing import TypeAlias
 

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -4,9 +4,14 @@ Tracing utils
 
 from __future__ import annotations
 
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Sequence, TypeAlias, Callable, Any, Tuple
+    from typing import Any
+    from typing import Callable
+    from typing import Sequence
+    from typing import Tuple
+    from typing import TypeAlias
 
 
 _Writer: TypeAlias = "Callable[[str], object]"

--- a/src/pluggy/_types.py
+++ b/src/pluggy/_types.py
@@ -1,0 +1,43 @@
+from typing import Mapping
+from typing import TypedDict
+import warnings
+
+
+warnings.warn(ImportWarning(f"{__name__} imported outside of type checking"))
+
+
+class HookspecOpts(TypedDict):
+    """Options for a hook specification."""
+
+    #: Whether the hook is :ref:`first result only <firstresult>`.
+    firstresult: bool
+    #: Whether the hook is :ref:`historic <historic>`.
+    historic: bool
+    #: Whether the hook :ref:`warns when implemented <warn_on_impl>`.
+    warn_on_impl: Warning | None
+    #: Whether the hook warns when :ref:`certain arguments are requested
+    #: <warn_on_impl>`.
+    #:
+    #: .. versionadded:: 1.5
+    warn_on_impl_args: Mapping[str, Warning] | None
+
+
+class HookimplOpts(TypedDict):
+    """Options for a hook implementation."""
+
+    #: Whether the hook implementation is a :ref:`wrapper <hookwrapper>`.
+    wrapper: bool
+    #: Whether the hook implementation is an :ref:`old-style wrapper
+    #: <old_style_hookwrappers>`.
+    hookwrapper: bool
+    #: Whether validation against a hook specification is :ref:`optional
+    #: <optionalhook>`.
+    optionalhook: bool
+    #: Whether to try to order this hook implementation :ref:`first
+    #: <callorder>`.
+    tryfirst: bool
+    #: Whether to try to order this hook implementation :ref:`last
+    #: <callorder>`.
+    trylast: bool
+    #: The name of the hook specification to match, see :ref:`specname`.
+    specname: str | None

--- a/src/pluggy/_types.py
+++ b/src/pluggy/_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Mapping
 from typing import TypedDict
 import warnings

--- a/src/pluggy/_types.py
+++ b/src/pluggy/_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from collections.abc import Mapping
 from typing import TypedDict
 import warnings
 


### PR DESCRIPTION
still breaking

this change youelds a speedup form 0.69s to 0.004s for pluggy imports, by deferring imports of the stdlib