### PR TITLE
Defer loading of importtlib.metadata

### DIFF
--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib.metadata
 import inspect
 import types
 import warnings
@@ -11,6 +10,7 @@ from typing import Final
 from typing import Iterable
 from typing import Mapping
 from typing import Sequence
+from typing import TYPE_CHECKING
 
 from . import _tracing
 from ._callers import _multicall
@@ -25,6 +25,10 @@ from ._hooks import HookRelay
 from ._hooks import HookspecOpts
 from ._hooks import normalize_hookimpl_opts
 from ._result import Result
+
+if TYPE_CHECKING:
+    # importtlib.metadata import is slow, defer it.
+    import importlib.metadata
 
 
 _BeforeTrace = Callable[[str, Sequence[HookImpl], Mapping[str, Any]], None]
@@ -384,6 +388,8 @@ class PluginManager:
         :return:
             The number of plugins loaded by this call.
         """
+        import importlib.metadata
+
         count = 0
         for dist in list(importlib.metadata.distributions()):
             for ep in dist.entry_points:


### PR DESCRIPTION
Refs https://github.com/pytest-dev/pluggy/pull/445#issuecomment-1732573535

This package is needed for `load_setuptools_entrypoints`, but it is quite slow to import. While most users do use
`load_setuptools_entrypoints`, maybe some don't, so let's let them avoid the cost.

For `import pluggy`:
Before: 36ms
After:  11ms