### PR TITLE
Fix formatting in wrappers docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -416,9 +416,11 @@ of the hook thus far, or, if the previous calls raised an exception, it is
 :py:meth:`thrown <python:generator.throw>` the exception.
 
 The function should do one of two things:
-- Return a value, which can be the same value as received from the ``yield``, or
-something else entirely.
+
+- Return a value, which can be the same value as received from the ``yield``, or something else entirely.
+
 - Raise an exception.
+
 The return value or exception propagate to further hook wrappers, and finally
 to the hook caller.
 


### PR DESCRIPTION
Noticed that part of the text is not being formatted correctly in readthedocs:

![image](https://github.com/pytest-dev/pluggy/assets/1085180/0a9d80b4-bc60-47e1-bf9a-97360491a00b)

After this PR:

![image](https://github.com/pytest-dev/pluggy/assets/1085180/13ce15d4-da55-43f9-ad5e-e1c3182a96d6)
