### PR TITLE
Add `PluginManager.unblock` method to unblock a name

### DIFF
--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -235,6 +235,16 @@ class PluginManager:
         """Return whether the given plugin name is blocked."""
         return name in self._name2plugin and self._name2plugin[name] is None
 
+    def unblock(self, name: str) -> bool:
+        """Unblocks a name.
+
+        Returns whether the name was actually blocked.
+        """
+        if self._name2plugin.get(name, -1) is None:
+            del self._name2plugin[name]
+            return True
+        return False
+
     def add_hookspecs(self, module_or_class: _Namespace) -> None:
         """Add new hook specifications defined in the given ``module_or_class``.
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -110,6 +110,13 @@ def test_set_blocked(pm: PluginManager) -> None:
     pm.unregister(name="somename")
     assert pm.is_blocked("somename")
 
+    # Unblock.
+    assert not pm.unblock("someothername")
+    assert pm.unblock("somename")
+    assert not pm.is_blocked("somename")
+    assert not pm.unblock("somename")
+    assert pm.register(A(), "somename")
+
 
 def test_register_mismatch_method(he_pm: PluginManager) -> None:
     class hello:


### PR DESCRIPTION
Pytest currently accesses internals to do this:
https://github.com/pytest-dev/pytest/blob/1b78de4e21d55983422e7327a51304ef0fc61679/src/_pytest/config/__init__.py#L740-L746 Let's provide a proper API for this.