### PR TITLE
Fix broken Kedro hooks link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -162,7 +162,7 @@ documentation and source code:
 * :ref:`pytest <pytest:writing-plugins>`
 * :std:doc:`tox <tox:plugins>`
 * :std:doc:`devpi <devpi:devguide/index>`
-* :std:doc:`kedro <kedro:kedro.framework.hooks.specs>`
+* :std:doc:`kedro <kedro:hooks/introduction>`
 
 For more details and advanced usage please read on.
 


### PR DESCRIPTION
The Kedro link on https://pluggy.readthedocs.io/en/stable/#more-real-world-examples

> To see how `pluggy` is used in the real world, have a look at these projects documentation and source code:
> 
> -   [pytest](https://docs.pytest.org/en/latest/how-to/writing_plugins.html#writing-plugins "(in pytest v8.1.0.dev95+g2a77f8d)")
> -   [tox](https://tox.wiki/en/latest/plugins.html "(in Python v4.12)")
> -   [devpi](https://devpi.net/docs/devpi/devpi/stable/+doc/devguide/index.html "(in devpi v6.9)")
> -   [kedro](https://docs.kedro.org/en/latest/kedro.framework.hooks.specs.html "(in kedro v0.19)")

Links to https://docs.kedro.org/en/latest/kedro.framework.hooks.specs.html which returns a 404 error

I think https://docs.kedro.org/en/latest/hooks/introduction.html is a better page to link to here.