### PR TITLE
fix #544: Correctly pass StopIteration trough wrappers

### DIFF
--- a/changelog/544.bugfix.rst
+++ b/changelog/544.bugfix.rst
@@ -1,0 +1,6 @@
+Correctly pass :class:`StopIteration` trough hook wrappers.
+
+Raising a :class:`StopIteration` in a generator triggers a :class:`RuntimeError`.
+
+If the :class:`RuntimeError` of a generator has the passed in :class:`StopIteration` as cause
+resume with that :class:`StopIteration` as normal exception instead of failing with the :class:`RuntimeError`.


### PR DESCRIPTION
Raising a StopIteration in a generator triggers a RuntimeError.
If the RuntimeError of a generator has the passed in StopIteration as cause
resume with that StopIteration as normal exception instead of failing with the RuntimeError.

closes #544 
