### PR TITLE
Unicode encoding error

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 include =
   pluggy/*
   src/pluggy/*
+  pluggy/testing/*
   testing/*
   */lib/python*/site-packages/pluggy/*
   */pypy*/site-packages/pluggy/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 include =
   pluggy/*
   src/pluggy/*
-  pluggy/testing/*
   testing/*
   */lib/python*/site-packages/pluggy/*
   */pypy*/site-packages/pluggy/*

--- a/changelog/13750(pytest).bugfix.rst
+++ b/changelog/13750(pytest).bugfix.rst
@@ -1,0 +1,3 @@
+This change addresses an issue in pluggy that occured when running pytest with any pluggy tracing enabled when parametrized values contained surrogate escape characters.
+Before, pluggy attempted to write trace messages using UTF-8 enconding, which fails for lone surrogates. Tracing now encodes lone surrogates with errors="replace" in order
+to ensure that trace logging will not crash hook execution in the future.

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -501,7 +501,7 @@ class PluginManager:
             kwargs: Mapping[str, object],
         ) -> None:
             if outcome.exception is None:
-                hooktrace("finish", hook_name, "-->", outcome.get_result())
+                hooktrace("finish", hook_name, "-->", repr(outcome.get_result()))
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -29,20 +29,20 @@ class TagTracer:
         else:
             extra = {}
 
-        content = " ".join(map(str, args))
+        content = " ".join(repr(a) for a in args)
         indent = "  " * self.indent
 
         lines = ["{}{} [{}]\n".format(indent, content, ":".join(tags))]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {value!r}\n")
 
         return "".join(lines)
 
     def _processmessage(self, tags: tuple[str, ...], args: tuple[object, ...]) -> None:
         if self._writer is not None and args:
-            msg = self._format_message(tags, args)
-            self._writer(msg.encode("utf-8", "replace").decode("utf-8"))
+            self._writer(self._format_message(tags, args))
+
         try:
             processor = self._tags2proc[tags]
         except KeyError:

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -41,7 +41,8 @@ class TagTracer:
 
     def _processmessage(self, tags: tuple[str, ...], args: tuple[object, ...]) -> None:
         if self._writer is not None and args:
-            self._writer(self._format_message(tags, args))
+            msg = self._format_message(tags, args)
+            self._writer(msg.encode("utf-8", "replace").decode("utf-8"))
         try:
             processor = self._tags2proc[tags]
         except KeyError:

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -75,3 +75,14 @@ def test_setprocessor(rootlogger: TagTracer) -> None:
     log2("seen")
     tags, args = l2[0]
     assert args == ("seen",)
+
+
+def test_unicode_surrogate_handling(rootlogger: TagTracer) -> None:
+    out: list[str] = []
+    rootlogger.setwriter(out.append)
+    log = rootlogger.get("pytest")
+    s = "hello \ud800 world"
+    log(s)
+    assert len(out) == 1
+    assert "\ud800" not in out
+    assert "hello ? world" in out[0]

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -15,10 +15,10 @@ def test_simple(rootlogger: TagTracer) -> None:
     rootlogger.setwriter(out.append)
     log("world")
     assert len(out) == 1
-    assert out[0] == "world [pytest]\n"
+    assert out[0] == "'world' [pytest]\n"
     sublog = log.get("collection")
     sublog("hello")
-    assert out[1] == "hello [pytest:collection]\n"
+    assert out[1] == "'hello' [pytest:collection]\n"
 
 
 def test_indent(rootlogger: TagTracer) -> None:
@@ -39,13 +39,13 @@ def test_indent(rootlogger: TagTracer) -> None:
     assert len(out) == 7
     names = [x[: x.rfind(" [")] for x in out]
     assert names == [
-        "hello",
-        "  line1",
-        "  line2",
-        "    line3",
-        "    line4",
-        "  line5",
-        "last",
+        "'hello'",
+        "  'line1'",
+        "  'line2'",
+        "    'line3'",
+        "    'line4'",
+        "  'line5'",
+        "'last'",
     ]
 
 
@@ -54,7 +54,7 @@ def test_readable_output_dictargs(rootlogger: TagTracer) -> None:
     assert out == "1 [test]\n"
 
     out2 = rootlogger._format_message(["test"], ["test", {"a": 1}])
-    assert out2 == "test [test]\n    a: 1\n"
+    assert out2 == "'test' [test]\n    a: 1\n"
 
 
 def test_setprocessor(rootlogger: TagTracer) -> None:
@@ -84,19 +84,4 @@ def test_unicode_surrogate_handling(rootlogger: TagTracer) -> None:
     s = "hello \ud800 world"
     log(s)
     assert len(out) == 1
-    assert "\ud800" not in out
-    assert "hello ? world" in out[0]
-
-
-def test_unicode_surrogate_handling_2(rootlogger: TagTracer) -> None:
-    out: list[str] = []
-    rootlogger.setwriter(out.append)
-    log = rootlogger.get("pytest")
-
-    bad = b"\xed\xa0\x80".decode("utf-8", "surrogatepass")
-
-    log(bad)
-
-    assert len(out) == 1
-    assert "\ud800" not in out[0]
-    assert "?" in out[0]
+    assert "hello \\ud800 world" in out[0]

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -86,3 +86,27 @@ def test_unicode_surrogate_handling(rootlogger: TagTracer) -> None:
     assert len(out) == 1
     assert "\ud800" not in out
     assert "hello ? world" in out[0]
+
+
+def test_unicode_surrogate_handling_2(rootlogger: TagTracer) -> None:
+    out: list[str] = []
+    rootlogger.setwriter(out.append)
+    log = rootlogger.get("pytest")
+
+    bad = b"\xed\xa0\x80".decode("utf-8", "surrogatepass")
+
+    log(bad)
+
+    assert len(out) == 1
+    assert "\ud800" not in out[0]
+    assert "?" in out[0]
+
+
+def test_unicode_surrogate_handling_normal(rootlogger: TagTracer) -> None:
+    out: list[str] = []
+    rootlogger.setwriter(out.append)
+    log = rootlogger.get("pytest")
+    s = "hello world"
+    log(s)
+    assert len(out) == 1
+    assert "hello world" in out[0]

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -100,13 +100,3 @@ def test_unicode_surrogate_handling_2(rootlogger: TagTracer) -> None:
     assert len(out) == 1
     assert "\ud800" not in out[0]
     assert "?" in out[0]
-
-
-def test_unicode_surrogate_handling_normal(rootlogger: TagTracer) -> None:
-    out: list[str] = []
-    rootlogger.setwriter(out.append)
-    log = rootlogger.get("pytest")
-    s = "hello world"
-    log(s)
-    assert len(out) == 1
-    assert "hello world" in out[0]


### PR DESCRIPTION
Fixing an issue with Pluggy where surrogate escape characters are not encoded correctly, causing a crash of Pluggy hooks. From issue [13750](https://github.com/pytest-dev/pytest/issues/13750) in Pytest. 