### PR TITLE
Divide and specialize hook impls/callers

### DIFF
--- a/src/pluggy/_callers.py
+++ b/src/pluggy/_callers.py
@@ -4,86 +4,18 @@ Call loop machinery
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from collections.abc import Mapping
 from collections.abc import Sequence
-from typing import cast
-from typing import NoReturn
-from typing import TypeAlias
-import warnings
 
-from ._hooks import _AnyHookImpl
-from ._hooks import _NewStyleWrapper
 from ._hooks import _NormalHookImplementation
-from ._hooks import _OldStyleWrapper
-from ._hooks import HookImpl
-from ._result import HookCallError
-from ._result import Result
-from ._warnings import PluggyTeardownRaisedWarning
-
-
-# Need to distinguish between old- and new-style hook wrappers.
-# Wrapping with a tuple is the fastest type-safe way I found to do it.
-Teardown: TypeAlias = Generator[None, object, object]
-
-
-def run_old_style_hookwrapper(
-    hook_impl: _AnyHookImpl, hook_name: str, args: Sequence[object]
-) -> Teardown:
-    """
-    backward compatibility wrapper to run a old style hookwrapper as a wrapper
-    """
-
-    teardown: Teardown = cast(Teardown, hook_impl.function(*args))
-    try:
-        next(teardown)
-    except StopIteration:
-        _raise_wrapfail(teardown, "did not yield")
-    try:
-        res = yield
-        result = Result(res, None)
-    except BaseException as exc:
-        result = Result(None, exc)
-    try:
-        teardown.send(result)
-    except StopIteration:
-        pass
-    except BaseException as e:
-        _warn_teardown_exception(hook_name, hook_impl, e)
-        raise
-    else:
-        _raise_wrapfail(teardown, "has second yield")
-    finally:
-        teardown.close()
-    return result.get_result()
-
-
-def _raise_wrapfail(
-    wrap_controller: Generator[None, object, object],
-    msg: str,
-) -> NoReturn:
-    co = wrap_controller.gi_code  # type: ignore[attr-defined]
-    raise RuntimeError(
-        f"wrap_controller at {co.co_name!r} {co.co_filename}:{co.co_firstlineno} {msg}"
-    )
-
-
-def _warn_teardown_exception(
-    hook_name: str, hook_impl: _AnyHookImpl, e: BaseException
-) -> None:
-    msg = (
-        f"A plugin raised an exception during an old-style hookwrapper teardown.\n"
-        f"Plugin: {hook_impl.plugin_name}, Hook: {hook_name}\n"
-        f"{type(e).__name__}: {e}\n"
-        f"For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning"  # noqa: E501
-    )
-    warnings.warn(PluggyTeardownRaisedWarning(msg), stacklevel=6)
+from ._hooks import _WrapperHookImplementation
+from ._hooks import Teardown
 
 
 def _multicall(
     hook_name: str,
-    normal_impls: Sequence[_AnyHookImpl],
-    wrapper_impls: Sequence[_AnyHookImpl],
+    normal_impls: Sequence[_NormalHookImplementation],
+    wrapper_impls: Sequence[_WrapperHookImplementation],
     caller_kwargs: Mapping[str, object],
     firstresult: bool,
 ) -> object | list[object]:
@@ -95,125 +27,34 @@ def _multicall(
     __tracebackhide__ = True
     results: list[object] = []
     exception = None
-    try:  # run impl and wrapper setup functions in a loop
-        teardowns: list[Teardown] = []
-        try:
-            # Phase 1: Run wrapper setup (in reverse - tryfirst wrappers run first)
-            for hook_impl in reversed(wrapper_impls):
-                try:
-                    args = [caller_kwargs[argname] for argname in hook_impl.argnames]
-                except KeyError as e:
-                    # coverage bug - this is tested
-                    for argname in hook_impl.argnames:  # pragma: no cover
-                        if argname not in caller_kwargs:
-                            raise HookCallError(
-                                f"hook call must provide argument {argname!r}"
-                            ) from e
+    teardowns: list[Teardown] = []
 
-                # Type-based dispatch for wrapper types
-                match hook_impl:
-                    case _OldStyleWrapper():
-                        function_gen = run_old_style_hookwrapper(
-                            hook_impl, hook_name, args
-                        )
-                        next(function_gen)  # first yield
-                        teardowns.append(function_gen)
+    try:
+        # Phase 1: Run wrapper setup (in reverse - tryfirst wrappers run first)
+        for wrapper in reversed(wrapper_impls):
+            teardowns.append(wrapper.setup_teardown(caller_kwargs))
 
-                    case _NewStyleWrapper():
-                        try:
-                            res = hook_impl.function(*args)
-                            function_gen = cast(Generator[None, object, object], res)
-                            next(function_gen)  # first yield
-                            teardowns.append(function_gen)
-                        except StopIteration:
-                            _raise_wrapfail(function_gen, "did not yield")
+        # Phase 2: Run normal impls (in reverse - tryfirst impls run first)
+        for impl in reversed(normal_impls):
+            res = impl.call(caller_kwargs)
+            if res is not None:
+                results.append(res)
+                if firstresult:  # halt further impl calls
+                    break
 
-                    # Backward compatibility with old HookImpl class
-                    case HookImpl() if hook_impl.hookwrapper:
-                        function_gen = run_old_style_hookwrapper(
-                            hook_impl, hook_name, args
-                        )
-                        next(function_gen)  # first yield
-                        teardowns.append(function_gen)
+    except BaseException as exc:
+        exception = exc
 
-                    case HookImpl() if hook_impl.wrapper:
-                        try:
-                            res = hook_impl.function(*args)
-                            function_gen = cast(Generator[None, object, object], res)
-                            next(function_gen)  # first yield
-                            teardowns.append(function_gen)
-                        except StopIteration:
-                            _raise_wrapfail(function_gen, "did not yield")
+    # Compute result before teardowns
+    if firstresult:
+        outcome: object = results[0] if results else None
+    else:
+        outcome = results
 
-            # Phase 2: Run normal impls (in reverse - tryfirst impls run first)
-            for hook_impl in reversed(normal_impls):
-                try:
-                    args = [caller_kwargs[argname] for argname in hook_impl.argnames]
-                except KeyError as e:
-                    # coverage bug - this is tested
-                    for argname in hook_impl.argnames:  # pragma: no cover
-                        if argname not in caller_kwargs:
-                            raise HookCallError(
-                                f"hook call must provide argument {argname!r}"
-                            ) from e
-
-                # Type-based dispatch for normal types
-                match hook_impl:
-                    case _NormalHookImplementation():
-                        res = hook_impl.function(*args)
-                        if res is not None:
-                            results.append(res)
-                            if firstresult:  # halt further impl calls
-                                break
-
-                    # Backward compatibility with old HookImpl class
-                    case HookImpl():
-                        res = hook_impl.function(*args)
-                        if res is not None:
-                            results.append(res)
-                            if firstresult:  # halt further impl calls
-                                break
-        except BaseException as exc:
-            exception = exc
-    finally:
-        if firstresult:  # first result hooks return a single value
-            result = results[0] if results else None
-        else:
-            result = results
-
-        # run all wrapper post-yield blocks
-        for teardown in reversed(teardowns):
-            try:
-                if exception is not None:
-                    try:
-                        teardown.throw(exception)
-                    except RuntimeError as re:
-                        # StopIteration from generator causes RuntimeError
-                        # even for coroutine usage - see #544
-                        if (
-                            isinstance(exception, StopIteration)
-                            and re.__cause__ is exception
-                        ):
-                            teardown.close()
-                            continue
-                        else:
-                            raise
-                else:
-                    teardown.send(result)
-                # Following is unreachable for a well behaved hook wrapper.
-                # Try to force finalizers otherwise postponed till GC action.
-                # Note: close() may raise if generator handles GeneratorExit.
-                teardown.close()
-            except StopIteration as si:
-                result = si.value
-                exception = None
-                continue
-            except BaseException as e:
-                exception = e
-                continue
-            _raise_wrapfail(teardown, "has second yield")
+    # Run all wrapper teardowns in reverse order
+    for teardown in reversed(teardowns):
+        outcome, exception = teardown(outcome, exception)
 
     if exception is not None:
         raise exception
-    else:
-        return result
+    return outcome

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -15,7 +15,6 @@ import warnings
 
 from . import _tracing
 from ._callers import _multicall
-from ._hooks import _AnyHookImpl
 from ._hooks import _create_hook_caller
 from ._hooks import _create_hook_implementation
 from ._hooks import _HistoricHookCaller
@@ -28,6 +27,7 @@ from ._hooks import _Plugin
 from ._hooks import _SpecifiedHookCaller
 from ._hooks import _SubsetHookCaller
 from ._hooks import _UnspeccedHookCaller
+from ._hooks import _WrapperHookImplementation
 from ._hooks import HookImpl
 from ._hooks import HookimplOpts
 from ._hooks import HookRelay
@@ -126,8 +126,8 @@ class PluginManager:
     def _hookexec(
         self,
         hook_name: str,
-        normal_impls: Sequence[_AnyHookImpl],
-        wrapper_impls: Sequence[_AnyHookImpl],
+        normal_impls: Sequence[_NormalHookImplementation],
+        wrapper_impls: Sequence[_WrapperHookImplementation],
         kwargs: Mapping[str, object],
         firstresult: bool,
     ) -> object | list[object]:
@@ -493,8 +493,8 @@ class PluginManager:
 
         def traced_hookexec(
             hook_name: str,
-            normal_impls: Sequence[_AnyHookImpl],
-            wrapper_impls: Sequence[_AnyHookImpl],
+            normal_impls: Sequence[_NormalHookImplementation],
+            wrapper_impls: Sequence[_WrapperHookImplementation],
             caller_kwargs: Mapping[str, object],
             firstresult: bool,
         ) -> object | list[object]:

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -192,7 +192,7 @@ def test_repr() -> None:
     plugin = Plugin()
     pname = pm.register(plugin)
     assert repr(pm.hook.myhook.get_hookimpls()[0]) == (
-        f"<HookImpl plugin_name={pname!r}, plugin={plugin!r}>"
+        f"<_NormalHookImplementation plugin_name={pname!r}, plugin={plugin!r}>"
     )
 
 

--- a/testing/test_invocations.py
+++ b/testing/test_invocations.py
@@ -40,7 +40,7 @@ def test_only_kwargs(pm: PluginManager) -> None:
 
     pm.add_hookspecs(Api)
     with pytest.raises(TypeError) as exc:
-        pm.hook.hello(3)  # type: ignore[call-arg]
+        pm.hook.hello(3)
 
     message = "__call__() takes 1 positional argument but 2 were given"
     assert message in str(exc.value)

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -8,7 +8,9 @@ from pluggy import HookCallError
 from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 from pluggy._callers import _multicall
-from pluggy._hooks import HookImpl
+from pluggy._hooks import _create_hook_implementation
+from pluggy._hooks import _NormalHookImplementation
+from pluggy._hooks import _WrapperHookImplementation
 
 
 hookspec = HookspecMarker("example")
@@ -21,14 +23,15 @@ def MC(
     firstresult: bool = False,
 ) -> object | list[object]:
     caller = _multicall
-    normal_funcs: list[HookImpl] = []
-    wrapper_funcs: list[HookImpl] = []
+    normal_funcs: list[_NormalHookImplementation] = []
+    wrapper_funcs: list[_WrapperHookImplementation] = []
     for method in methods:
-        f = HookImpl(None, "<temp>", method, method.example_impl)  # type: ignore[attr-defined]
-        if f.wrapper or f.hookwrapper:
-            wrapper_funcs.append(f)
+        opts = method.example_impl  # type: ignore[attr-defined]
+        f = _create_hook_implementation(None, "<temp>", method, opts)
+        if f.is_wrapper:
+            wrapper_funcs.append(f)  # type: ignore[arg-type]
         else:
-            normal_funcs.append(f)
+            normal_funcs.append(f)  # type: ignore[arg-type]
     return caller("foo", normal_funcs, wrapper_funcs, kwargs, firstresult)
 
 

--- a/testing/test_multicall.py
+++ b/testing/test_multicall.py
@@ -21,11 +21,15 @@ def MC(
     firstresult: bool = False,
 ) -> object | list[object]:
     caller = _multicall
-    hookfuncs = []
+    normal_funcs: list[HookImpl] = []
+    wrapper_funcs: list[HookImpl] = []
     for method in methods:
         f = HookImpl(None, "<temp>", method, method.example_impl)  # type: ignore[attr-defined]
-        hookfuncs.append(f)
-    return caller("foo", hookfuncs, kwargs, firstresult)
+        if f.wrapper or f.hookwrapper:
+            wrapper_funcs.append(f)
+        else:
+            normal_funcs.append(f)
+    return caller("foo", normal_funcs, wrapper_funcs, kwargs, firstresult)
 
 
 def test_keyword_args() -> None:

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -650,7 +650,7 @@ def test_add_tracefuncs(he_pm: PluginManager) -> None:
     assert isinstance(out[0][2], dict)
     assert out[1] == "he_method1-api2"
     assert out[2] == "he_method1-api1"
-    assert len(out[3]) == 4
+    assert len(out[3]) == 4  # (outcome, hook_name, combined_impls, kwargs)
     assert out[3][1] == out[0][0]
 
     undo()


### PR DESCRIPTION
## Summary

- Introduce class hierarchies for hook callers (`_NormalHookCaller`, `_FirstResultHookCaller`, `_HistoricHookCaller`) and implementations (`_NormalHookImplementation`, `_NewStyleWrapper`, `_OldStyleWrapper`)
- Each implementation type knows how to call itself or setup/teardown its wrapper
- The core `_multicall` loop becomes trivially simple:
  ```python
  for wrapper in reversed(wrapper_impls):
      teardowns.append(wrapper.setup_teardown(caller_kwargs))
  for impl in reversed(normal_impls):
      res = impl.call(caller_kwargs)
  for teardown in reversed(teardowns):
      outcome, exception = teardown(outcome, exception)
  ```

## Test plan
- [x] All 124 tests pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)