### PR TITLE
Add python-lsp-server to downstream tests

### DIFF
--- a/downstream/python-lsp-server.sh
+++ b/downstream/python-lsp-server.sh
@@ -1,0 +1,31 @@
+set -eux -o pipefail
+if [[ ! -d python-lsp-server ]]; then
+	git clone https://github.com/python-lsp/python-lsp-server.git
+fi
+
+pushd python-lsp-server
+trap popd EXIT
+
+git pull
+
+python -m venv venv
+
+if [[ "$OS" == "Windows_NT" ]]; then
+    VENV_PYTHON="venv/Scripts/python"
+    VENV_PYTEST="venv/Scripts/pytest"
+else
+    VENV_PYTHON="venv/bin/python"
+    VENV_PYTEST="venv/bin/pytest"
+fi
+
+# upgrade pip safely
+"$VENV_PYTHON" -m pip install -U pip
+
+# install python-lsp-server test deps
+"$VENV_PYTHON" -m pip install -e .[test]
+
+# install local pluggy
+"$VENV_PYTHON" -m pip install -e ..
+
+# run tests
+"$VENV_PYTEST" || true


### PR DESCRIPTION
This PR adds python-lsp-server as a downstream project to validate pluggy compatibility.

The downstream script installs the local pluggy worktree and runs the python-lsp-server test suite. Some plugin tests depend on optional third-party dependencies (for example, rope, flake8, pycodestyle) and may fail during collection. These failures are allowed to avoid gating CI, while still providing useful downstream signal.

This follows the existing downstream testing pattern used in the repository.

Closes #465