### PR TITLE
docs: fix incorrect :py:class: role for method reference

### DIFF
--- a/changelog/186.doc.rst
+++ b/changelog/186.doc.rst
@@ -1,0 +1,3 @@
+Fix incorrect ``:py:class:`` role used for a method reference in
+``docs/index.rst``; ``PluginManager.add_hookcall_monitoring()`` is
+now correctly referenced with ``:py:meth:``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -996,7 +996,7 @@ Call monitoring
 ---------------
 Instead of using the built-in tracing mechanism you can also add your
 own ``before`` and ``after`` monitoring functions using
-:py:class:`pluggy.PluginManager.add_hookcall_monitoring()`.
+:py:meth:`pluggy.PluginManager.add_hookcall_monitoring()`.
 
 The expected signature and default implementations for these functions is:
 


### PR DESCRIPTION
Fixes #186

`PluginManager.add_hookcall_monitoring()` is a method, not a class. The docs used `:py:class:` which generates a broken cross-reference link. Changed to `:py:meth:` so Sphinx correctly links to the method documentation.

**Before:**
```rst
:py:class:`pluggy.PluginManager.add_hookcall_monitoring()`.
```

**After:**
```rst
:py:meth:`pluggy.PluginManager.add_hookcall_monitoring()`.
```