### PR TITLE
create an optimized shortcut if `__code__` is seen and callable is a routine

### DIFF
--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -357,9 +357,9 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     try:
         # func MUST be a function or method here or we won't parse any args.
         func = func.__func__ if inspect.ismethod(func) else func
-        if hasattr(func, "__signature__") and hasattr(func, "__code__"):
+        if hasattr(func, "__code__") and inspect.isroutine(func):
             # Take the optimized approch rather than sit and parse the given signature.
-            args, kwargs = _varnames_from_code(func)
+            args, kwargs = _varnames_from_code(inspect.unwrap(func))
         else:
             # Fallback
             args, kwargs = _varnames_from_signature(func)

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -12,7 +12,6 @@ from collections.abc import Set
 import inspect
 import sys
 from types import ModuleType
-from types import MethodType
 from typing import Any
 from typing import Final
 from typing import final

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -12,6 +12,7 @@ from collections.abc import Set
 import inspect
 import sys
 from types import ModuleType
+from types import MethodType
 from typing import Any
 from typing import Final
 from typing import final
@@ -289,32 +290,23 @@ def normalize_hookimpl_opts(opts: HookimplOpts) -> None:
 
 _PYPY = hasattr(sys, "pypy_version_info")
 
+def _varnames_from_code(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Faster shortcut than needing to parse a function's given signature."""
+    code = func.__code__
+    pos_count = code.co_argcount
+    args = code.co_varnames[:pos_count]
 
-def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Return tuple of positional and keywrord argument names for a function,
-    method, class or callable.
+    if defaults := func.__defaults__:
+        index = -len(defaults)
+        return args[:index], tuple(args[index:])
+    else:
+        return args, ()
 
-    In case of a class, its ``__init__`` method is considered.
-    For methods the ``self`` parameter is not included.
-    """
-    if inspect.isclass(func):
-        try:
-            func = func.__init__
-        except AttributeError:  # pragma: no cover - pypy special case
-            return (), ()
-    elif not inspect.isroutine(func):  # callable object?
-        try:
-            func = getattr(func, "__call__", func)
-        except Exception:  # pragma: no cover - pypy special case
-            return (), ()
-
-    try:
-        # func MUST be a function or method here or we won't parse any args.
-        sig = inspect.signature(
-            func.__func__ if inspect.ismethod(func) else func  # type:ignore[arg-type]
-        )
-    except TypeError:  # pragma: no cover
-        return (), ()
+def _varnames_from_signature(func: object) ->  tuple[tuple[str, ...], tuple[str, ...]]:
+    """extracts from a function's given signature"""
+    sig = inspect.signature(
+            func  # type:ignore[arg-type]
+    )
 
     _valid_param_kinds = (
         inspect.Parameter.POSITIONAL_ONLY,
@@ -337,9 +329,39 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
 
     if defaults:
         index = -len(defaults)
-        args, kwargs = args[:index], tuple(args[index:])
+        return args[:index], tuple(args[index:])
     else:
-        kwargs = ()
+        return args, ()
+
+def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return tuple of positional and keywrord argument names for a function,
+    method, class or callable.
+
+    In case of a class, its ``__init__`` method is considered.
+    For methods the ``self`` parameter is not included.
+    """
+    if inspect.isclass(func):
+        try:
+            func = func.__init__
+        except AttributeError:  # pragma: no cover - pypy special case
+            return (), ()
+    elif not inspect.isroutine(func):  # callable object?
+        try:
+            func = getattr(func, "__call__", func)
+        except Exception:  # pragma: no cover - pypy special case
+            return (), ()
+
+    try:
+        # func MUST be a function or method here or we won't parse any args.
+        func = func.__func__ if inspect.ismethod(func) else func
+        if hasattr(func, "__signature__"):
+            # Take the optimized approch rather than sit and parse the given signature.
+            args, kwargs = _varnames_from_code(func)
+        else:
+            # Fallback
+            args, kwargs = _varnames_from_signature(func)  # type:ignore[arg-type]
+    except TypeError:  # pragma: no cover
+        return (), ()
 
     # strip any implicit instance arg
     # pypy3 uses "obj" instead of "self" for default dunder methods

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -12,7 +12,6 @@ from collections.abc import Set
 import inspect
 import sys
 from types import ModuleType
-from types import MethodType
 from typing import Any
 from typing import Final
 from typing import final
@@ -290,6 +289,7 @@ def normalize_hookimpl_opts(opts: HookimplOpts) -> None:
 
 _PYPY = hasattr(sys, "pypy_version_info")
 
+
 def _varnames_from_code(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Faster shortcut than needing to parse a function's given signature."""
     code = func.__code__
@@ -302,10 +302,11 @@ def _varnames_from_code(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]
     else:
         return args, ()
 
-def _varnames_from_signature(func: object) ->  tuple[tuple[str, ...], tuple[str, ...]]:
+
+def _varnames_from_signature(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """extracts from a function's given signature"""
     sig = inspect.signature(
-            func  # type:ignore[arg-type]
+        func  # type:ignore[arg-type]
     )
 
     _valid_param_kinds = (
@@ -332,6 +333,7 @@ def _varnames_from_signature(func: object) ->  tuple[tuple[str, ...], tuple[str,
         return args[:index], tuple(args[index:])
     else:
         return args, ()
+
 
 def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Return tuple of positional and keywrord argument names for a function,

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from collections.abc import Set
 import inspect
 import sys
+from types import CodeType
 from types import ModuleType
 from typing import Any
 from typing import Final
@@ -292,11 +293,11 @@ _PYPY = hasattr(sys, "pypy_version_info")
 
 def _varnames_from_code(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Faster shortcut than needing to parse a function's given signature."""
-    code = func.__code__
+    code: CodeType = getattr(func, "__code__")
     pos_count = code.co_argcount
     args = code.co_varnames[:pos_count]
 
-    if defaults := func.__defaults__:
+    if defaults := getattr(func, "__defaults__", None):
         index = -len(defaults)
         return args[:index], tuple(args[index:])
     else:
@@ -356,12 +357,12 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     try:
         # func MUST be a function or method here or we won't parse any args.
         func = func.__func__ if inspect.ismethod(func) else func
-        if hasattr(func, "__signature__"):
+        if hasattr(func, "__signature__") and hasattr(func, "__code__"):
             # Take the optimized approch rather than sit and parse the given signature.
             args, kwargs = _varnames_from_code(func)
         else:
             # Fallback
-            args, kwargs = _varnames_from_signature(func)  # type:ignore[arg-type]
+            args, kwargs = _varnames_from_signature(func)
     except TypeError:  # pragma: no cover
         return (), ()
 


### PR DESCRIPTION
While in the middle of trying to create my own asynchronous callback library I came up with a more optimized approach for extracting function arguments and I wanted to see if this could be a little bit faster here since construction of `inspect.signature` can be a little slow depending on the circumstances.