### PR TITLE
Handle broken repr in tracing

### DIFF
--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -13,6 +13,13 @@ _Writer = Callable[[str], object]
 _Processor = Callable[[tuple[str, ...], tuple[Any, ...]], object]
 
 
+def _safe_str(obj: object) -> str:
+    try:
+        return str(obj)
+    except Exception as exc:
+        return f"{object.__repr__(obj)} (str failed: {type(exc).__name__}: {exc})"
+
+
 class TagTracer:
     def __init__(self) -> None:
         self._tags2proc: dict[tuple[str, ...], _Processor] = {}
@@ -29,13 +36,13 @@ class TagTracer:
         else:
             extra = {}
 
-        content = " ".join(map(str, args))
+        content = " ".join(_safe_str(arg) for arg in args)
         indent = "  " * self.indent
 
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {_safe_str(value)}\n")
 
         return "".join(lines)
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -695,6 +695,33 @@ def test_hook_tracing(he_pm: PluginManager) -> None:
         undo()
 
 
+def test_hook_tracing_with_broken_repr(he_pm: PluginManager) -> None:
+    class BadRepr:
+        def __repr__(self) -> str:
+            raise RuntimeError("broken repr")
+
+    class api1:
+        @hookimpl
+        def he_method1(self, arg):
+            return None
+
+    he_pm.register(api1())
+    out: list[str] = []
+    he_pm.trace.root.setwriter(out.append)
+    undo = he_pm.enable_tracing()
+    try:
+        result = he_pm.hook.he_method1(arg=BadRepr())
+    finally:
+        undo()
+
+    assert result == []
+    assert len(out) == 2
+    assert "he_method1" in out[0]
+    assert "arg:" in out[0]
+    assert "BadRepr" in out[0]
+    assert "finish" in out[1]
+
+
 @pytest.mark.parametrize("historic", [False, True])
 def test_register_while_calling(
     pm: PluginManager,


### PR DESCRIPTION
## Summary
- guard tracing stringification so hook tracing does not break hook execution when traced objects have a broken `__repr__`/`__str__`
- keep the fallback output informative by using the default object repr and the original exception
- add a regression test covering broken repr values in traced hook kwargs

## Testing
- `uv run --python 3.12 pytest testing/test_pluginmanager.py -k broken_repr -q`
- `uv run --python 3.12 pytest testing/test_pluginmanager.py -q`

Closes #424.