### PR TITLE
fix: request signature with annotation format STRING

### DIFF
--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -36,6 +36,16 @@ _HookExec: TypeAlias = Callable[
 ]
 _HookImplFunction: TypeAlias = Callable[..., _T | Generator[None, Result[_T], None]]
 
+if sys.version_info >= (3, 14):
+    from annotationlib import Format
+
+    def _signature(func: Callable[..., object]) -> inspect.Signature:
+        return inspect.signature(func, annotation_format=Format.STRING)
+else:
+
+    def _signature(func: Callable[..., object]) -> inspect.Signature:
+        return inspect.signature(func)
+
 
 class HookspecOpts(TypedDict):
     """Options for a hook specification."""
@@ -310,7 +320,7 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
 
     try:
         # func MUST be a function or method here or we won't parse any args.
-        sig = inspect.signature(
+        sig = _signature(
             func.__func__ if inspect.ismethod(func) else func  # type:ignore[arg-type]
         )
     except TypeError:  # pragma: no cover

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -18,6 +18,7 @@ from ._callers import _multicall
 from ._hooks import _HookImplFunction
 from ._hooks import _Namespace
 from ._hooks import _Plugin
+from ._hooks import _signature
 from ._hooks import _SubsetHookCaller
 from ._hooks import HookCaller
 from ._hooks import HookImpl
@@ -522,4 +523,4 @@ class PluginManager:
 
 
 def _formatdef(func: Callable[..., object]) -> str:
-    return f"{func.__name__}{inspect.signature(func)}"
+    return f"{func.__name__}{_signature(func)}"

--- a/testing/test_helpers.py
+++ b/testing/test_helpers.py
@@ -1,11 +1,18 @@
 from collections.abc import Callable
 from functools import wraps
+import sys
 from typing import Any
 from typing import cast
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from pluggy._hooks import varnames
 from pluggy._manager import _formatdef
+
+
+if TYPE_CHECKING:
+    # Cannot use typing.Tuple due to pyupgrade replacing it with tuple
+    from non_existent_module import Tuple
 
 
 def test_varnames() -> None:
@@ -88,6 +95,32 @@ def test_formatdef() -> None:
         pass
 
     assert _formatdef(function4) == "function4(arg1, *args, **kwargs)"
+
+
+def test_varnames_with_annotations() -> None:
+    if sys.version_info >= (3, 14):
+
+        def hook(arg1: Tuple[int]) -> None:  # type: ignore[no-any-unimported]
+            pass
+    else:
+
+        def hook(arg1: "Tuple[int]") -> "None":  # type: ignore[no-any-unimported]
+            pass
+
+    assert varnames(hook) == (("arg1",), ())
+
+
+def test_formatdef_with_annotations() -> None:
+    if sys.version_info >= (3, 14):
+
+        def hook(arg1: Tuple[int]) -> None:  # type: ignore[no-any-unimported]
+            pass
+    else:
+
+        def hook(arg1: "Tuple[int]") -> "None":  # type: ignore[no-any-unimported]
+            pass
+
+    assert _formatdef(hook) == "hook(arg1: 'Tuple[int]') -> 'None'"
 
 
 def test_varnames_decorator() -> None:


### PR DESCRIPTION
On Python 3.14+ the default annotation format is `Format.VALUE` which causes an error when requesting a signature with an undefined name.

On Python 3.14, `ruff` suggests to move certain imports into type checking blocks, leading for example to the following:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from _pytest.config import Config
    from _pytest.main import Session
    from _pytest.python import Function

def pytest_collection_modifyitems(session: Session, config: Config, items: list[Function]) -> None:
    ...
```

Causing:

```console
.venv/lib/python3.14/site-packages/pluggy/_manager.py:161: in register
    hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/pluggy/_hooks.py:664: in __init__
    argnames, kwargnames = varnames(self.function)
                           ^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.14/site-packages/pluggy/_hooks.py:313: in varnames
    sig = inspect.signature(
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/inspect.py:3323: in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/inspect.py:3038: in from_callable
    return _signature_from_callable(obj, sigcls=cls,
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/inspect.py:2512: in _signature_from_callable
    return _signature_from_function(sigcls, obj,
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/inspect.py:2335: in _signature_from_function
    annotations = get_annotations(func, globals=globals, locals=locals, eval_str=eval_str,
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/annotationlib.py:966: in get_annotations
    ann = _get_dunder_annotations(obj)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../../../.local/share/uv/python/cpython-3.14.4-macos-aarch64-none/lib/python3.14/annotationlib.py:1159: in _get_dunder_annotations
    ann = getattr(obj, "__annotations__", None)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
opal/conftest.py:45: in __annotate__
    def pytest_collection_modifyitems(session: Session, config: Config, items: list[Function]) -> None:
                                               ^^^^^^^
E   NameError: name 'Session' is not defined
```

Changing the annotation format to `STRING` fixes this.