### PR TITLE
chore: fix coverage report paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,9 +7,10 @@ include =
   */pypy*/site-packages/pluggy/*
   *\Lib\site-packages\pluggy\*
 branch = 1
+parallel = true
 
 [paths]
-source = pluggy/
+source = src/pluggy/
   */lib/python*/site-packages/pluggy/
   */pypy*/site-packages/pluggy/
   *\Lib\site-packages\pluggy\

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -345,7 +345,7 @@ def varnames(func: object) -> tuple[tuple[str, ...], tuple[str, ...]]:
     # pypy3 uses "obj" instead of "self" for default dunder methods
     if not _PYPY:
         implicit_names: tuple[str, ...] = ("self",)
-    else:  # pragma: no cover
+    else:
         implicit_names = ("self", "obj")
     if args:
         qualname: str = getattr(func, "__qualname__", "")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=docs,py{310,311,312,313,314,py3},py{310}-pytestmain
 [testenv]
 commands=
   {env:_PLUGGY_TOX_CMD:pytest} {posargs}
+  coverage: coverage combine
   coverage: coverage report -m
   coverage: coverage xml
 setenv=


### PR DESCRIPTION
Noticed when working on #668 that the coverage report shows missing coverage when it is indeed covered.

Did some troubleshooting and found out that the files are shown inside `.tox` (see: https://github.com/pytest-dev/pluggy/actions/runs/25109365911/job/73578995307?pr=668#step:7:45).

`coverage combine` is required to rewrite the paths.

As a result, there are probably a few `# pragma: no cover` that can be removed.

