### PR TITLE
docs: fix external project references

### DIFF
--- a/changelog/186.doc.rst
+++ b/changelog/186.doc.rst
@@ -1,0 +1,1 @@
+Fixed broken external documentation references in the list of projects using pluggy.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,9 +160,9 @@ To see how ``pluggy`` is used in the real world, have a look at these projects
 documentation and source code:
 
 * :ref:`pytest <pytest:writing-plugins>`
-* :std:doc:`tox <tox:plugins>`
+* `tox <https://tox.wiki/en/latest/plugins.html>`__
 * :std:doc:`devpi <devpi:devguide/index>`
-* :std:doc:`kedro <kedro:hooks/introduction>`
+* `Kedro <https://docs.kedro.org/en/stable/hooks/introduction/>`__
 
 For more details and advanced usage please read on.
 


### PR DESCRIPTION
Closes #186.

## Summary
- Replace broken intersphinx references for tox and Kedro with direct documentation links
- Add a documentation changelog fragment

## Tests
- `PATH=/tmp/pluggy-docs-venv/bin:$PATH /tmp/pluggy-docs-venv/bin/python scripts/towncrier-draft-to-file.py && /tmp/pluggy-docs-venv/bin/sphinx-build -W -b html docs /tmp/pluggy-docs-build -t changelog_towncrier_draft`