### PR TITLE
docs: clarify hookimpl arguments with defaults

### DIFF
--- a/changelog/522.doc.rst
+++ b/changelog/522.doc.rst
@@ -1,0 +1,1 @@
+Document that hook implementation arguments with default values are not passed by pluggy.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -570,6 +570,12 @@ To allow for *hookspecs* to evolve over the lifetime of a project,
 This allows for extending hook arguments (and thus semantics) without
 breaking existing *hookimpls*.
 
+Only arguments without default values are considered for this opt-in
+matching. Arguments with defaults in a *hookimpl* are treated as optional
+keyword arguments and are not passed by pluggy, even when the hook caller
+provides a value with the same name. If a *hookimpl* needs a value from the
+hook call, declare it without a default value.
+
 In other words this is ok:
 
 .. code-block:: python


### PR DESCRIPTION
Document that hook implementation arguments with default values are treated as optional and are not passed by pluggy, even if the hook caller provides a matching keyword.

Closes #522.

Tests:
- `git diff --check`
- `uv run --with tox tox -e docs` (fails before building docs because Sphinx cannot fetch the external pytest intersphinx inventory: DNS resolution for docs.pytest.org)