### PR TITLE
Escape surrogate values in tracing output

### DIFF
--- a/changelog/681.bugfix.rst
+++ b/changelog/681.bugfix.rst
@@ -1,0 +1,1 @@
+Fix tracing output to safely escape surrogate characters in hook arguments and return values.

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -503,7 +503,7 @@ class PluginManager:
             kwargs: Mapping[str, object],
         ) -> None:
             if outcome.exception is None:
-                hooktrace("finish", hook_name, "-->", outcome.get_result())
+                hooktrace("finish", hook_name, "-->", repr(outcome.get_result()))
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -35,7 +35,7 @@ class TagTracer:
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {value!r}\n")
 
         return "".join(lines)
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -695,6 +695,39 @@ def test_hook_tracing(he_pm: PluginManager) -> None:
         undo()
 
 
+def test_hook_tracing_escapes_surrogate_values(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec(firstresult=True)
+        def he_method1(self, arg: object) -> object:
+            raise NotImplementedError()
+
+    class Plugin:
+        @hookimpl
+        def he_method1(self, arg: object) -> object:
+            return arg
+
+    out: list[str] = []
+
+    def write(message: str) -> None:
+        message.encode()
+        out.append(message)
+
+    pm.add_hookspecs(Hooks)
+    pm.register(Plugin())
+    pm.trace.root.setwriter(write)
+    undo = pm.enable_tracing()
+    try:
+        result = pm.hook.he_method1(arg="\ud800")
+    finally:
+        undo()
+
+    assert result == "\ud800"
+    assert out == [
+        "  he_method1 [hook]\n      arg: '\\ud800'\n",
+        "  finish he_method1 --> '\\ud800' [hook]\n",
+    ]
+
+
 @pytest.mark.parametrize("historic", [False, True])
 def test_register_while_calling(
     pm: PluginManager,

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -57,6 +57,12 @@ def test_readable_output_dictargs(rootlogger: TagTracer) -> None:
     assert out2 == "test [test]\n    a: 1\n"
 
 
+def test_dictargs_escape_surrogate_values(rootlogger: TagTracer) -> None:
+    out = rootlogger._format_message(["test"], ["test", {"arg": "\ud800"}])
+    assert out == "test [test]\n    arg: '\\ud800'\n"
+    out.encode()
+
+
 def test_setprocessor(rootlogger: TagTracer) -> None:
     log = rootlogger.get("1")
     log2 = log.get("2")


### PR DESCRIPTION
## Summary
- Use epr() for hook kwarg values in trace output so surrogate characters are escaped safely.
- Pre-format hook return values before writing tracing output while keeping structural trace labels readable.
- Add regression tests for surrogate values in hook arguments and return values.

## Tests
- git diff --check
- PYTHONPATH=src python -m pytest testing\\test_tracer.py::test_dictargs_escape_surrogate_values testing\\test_pluginmanager.py::test_hook_tracing_escapes_surrogate_values -q (2 passed)
- PYTHONPATH=src python -m pytest testing\\test_tracer.py testing\\test_pluginmanager.py -q (49 passed)

Fixes #681.