### PR TITLE
Fix four outdated links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Running this directly gets us::
     :target: https://gitter.im/pytest-dev/pluggy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/ambv/black
+    :target: https://github.com/psf/black
 
 .. |codecov| image:: https://codecov.io/gh/pytest-dev/pluggy/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/pytest-dev/pluggy
@@ -92,11 +92,11 @@ Running this directly gets us::
 
 .. links
 .. _pytest:
-    http://pytest.org
+    https://pytest.org
 .. _tox:
-    https://tox.readthedocs.org
+    https://tox.wiki/
 .. _devpi:
-    http://doc.devpi.net
+    https://doc.devpi.net
 .. _read the docs:
    https://pluggy.readthedocs.io/en/latest/
 

--- a/changelog/691.trivial.rst
+++ b/changelog/691.trivial.rst
@@ -1,0 +1,1 @@
+Fix outdated links in ``README.rst``: update ``http://pytest.org`` to ``https://pytest.org``, ``tox.readthedocs.org`` to ``tox.wiki``, ``http://doc.devpi.net`` to ``https://doc.devpi.net``, and the Black badge link from ``ambv/black`` to ``psf/black``.


### PR DESCRIPTION
## Summary

Fix four outdated links in `README.rst`:

- `http://pytest.org` → `https://pytest.org` (HTTP → HTTPS)
- `https://tox.readthedocs.org` → `https://tox.wiki/` (tox moved its docs from ReadTheDocs to tox.wiki)
- `http://doc.devpi.net` → `https://doc.devpi.net` (HTTP → HTTPS)
- `https://github.com/ambv/black` (Black badge) → `https://github.com/psf/black` (Black's repository was transferred to the `psf` GitHub org in 2020)

These are all small link fixes with no functional changes.

I'll add a changelog fragment once I have the PR number.
