### PR TITLE
unattended ai mess

### DIFF
--- a/changelog/694.bugfix.rst
+++ b/changelog/694.bugfix.rst
@@ -1,0 +1,1 @@
+Roll back plugin registration state when a validation error is raised partway through registering a plugin.

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -151,26 +151,28 @@ class PluginManager:
                 f"{plugin_name}={plugin}\n{self._name2plugin}"
             )
 
-        # XXX if an error happens we should make sure no state has been
-        # changed at point of return
         self._name2plugin[plugin_name] = plugin
 
-        # register matching hook implementations of the plugin
-        for name in dir(plugin):
-            hookimpl_opts = self.parse_hookimpl_opts(plugin, name)
-            if hookimpl_opts is not None:
-                normalize_hookimpl_opts(hookimpl_opts)
-                method: _HookImplFunction[object] = getattr(plugin, name)
-                hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
-                name = hookimpl_opts.get("specname") or name
-                hook: HookCaller | None = getattr(self.hook, name, None)
-                if hook is None:
-                    hook = HookCaller(name, self._hookexec)
-                    setattr(self.hook, name, hook)
-                elif hook.has_spec():
-                    self._verify_hook(hook, hookimpl)
-                    hook._maybe_apply_history(hookimpl)
-                hook._add_hookimpl(hookimpl)
+        try:
+            # register matching hook implementations of the plugin
+            for name in dir(plugin):
+                hookimpl_opts = self.parse_hookimpl_opts(plugin, name)
+                if hookimpl_opts is not None:
+                    normalize_hookimpl_opts(hookimpl_opts)
+                    method: _HookImplFunction[object] = getattr(plugin, name)
+                    hookimpl = HookImpl(plugin, plugin_name, method, hookimpl_opts)
+                    name = hookimpl_opts.get("specname") or name
+                    hook: HookCaller | None = getattr(self.hook, name, None)
+                    if hook is None:
+                        hook = HookCaller(name, self._hookexec)
+                        setattr(self.hook, name, hook)
+                    elif hook.has_spec():
+                        self._verify_hook(hook, hookimpl)
+                        hook._maybe_apply_history(hookimpl)
+                    hook._add_hookimpl(hookimpl)
+        except BaseException:
+            self.unregister(plugin, plugin_name)
+            raise
         return plugin_name
 
     def parse_hookimpl_opts(self, plugin: _Plugin, name: str) -> HookimplOpts | None:

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -151,6 +151,39 @@ def test_register_mismatch_arg(he_pm: PluginManager) -> None:
     assert excinfo.value.plugin is plugin
 
 
+def test_register_validation_failure_rolls_back(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec
+        def he_alpha(self, arg: int) -> int:
+            raise NotImplementedError()
+
+        @hookspec
+        def he_beta(self, arg: int) -> int:
+            raise NotImplementedError()
+
+    pm.add_hookspecs(Hooks)
+
+    class Plugin:
+        @hookimpl
+        def he_alpha(self, arg: int) -> int:
+            return arg
+
+        @hookimpl
+        def he_beta(self, arg: int, extra: int) -> int:
+            return arg + extra  # pragma: no cover
+
+    plugin = Plugin()
+
+    with pytest.raises(PluginValidationError) as excinfo:
+        pm.register(plugin, name="bad")
+    assert excinfo.value.plugin is plugin
+    assert pm.get_plugin("bad") is None
+    assert not pm.is_registered(plugin)
+    assert pm.get_plugins() == set()
+    assert pm.hook.he_alpha.get_hookimpls() == []
+    assert pm.hook.he_beta.get_hookimpls() == []
+
+
 def test_register_hookwrapper_not_a_generator_function(he_pm: PluginManager) -> None:
     class hello:
         @hookimpl(hookwrapper=True)


### PR DESCRIPTION
## Summary
- Roll back plugin manager state when plugin registration fails during hook validation or history replay.
- Add a regression test covering both the plugin name registry and hook implementation cleanup.

## Root cause
`PluginManager.register()` inserted the plugin into `_name2plugin` before validating all hook implementations. If a later hook implementation raised `PluginValidationError`, earlier state remained visible and the failed plugin name could not be reused.

## Tests
- `uv run pytest testing/test_pluginmanager.py::test_register_validation_failure_rolls_back` (failed before the fix, passes after)
- `uv run pytest`