### PR TITLE
Handle specname hooks in subset callers

### DIFF
--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -515,7 +515,12 @@ class PluginManager:
         method which manages calls to all registered plugins except the ones
         from remove_plugins."""
         orig: HookCaller = getattr(self.hook, name)
-        plugins_to_remove = {plug for plug in remove_plugins if hasattr(plug, name)}
+        remove_plugins = list(remove_plugins)
+        plugins_to_remove = {
+            hookimpl.plugin
+            for hookimpl in orig.get_hookimpls()
+            if any(hookimpl.plugin is plugin for plugin in remove_plugins)
+        }
         if plugins_to_remove:
             return _SubsetHookCaller(orig, plugins_to_remove)
         return orig

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -497,6 +497,32 @@ def test_subset_hook_caller(pm: PluginManager) -> None:
     assert repr(hc) == "<_SubsetHookCaller 'he_method1'>"
 
 
+def test_subset_hook_caller_with_specname(pm: PluginManager) -> None:
+    class Hooks:
+        @hookspec
+        def he_method1(self, arg):
+            pass
+
+    pm.add_hookspecs(Hooks)
+
+    class Plugin1:
+        @hookimpl(specname="he_method1")
+        def alias(self, arg):
+            return arg
+
+    class Plugin2:
+        @hookimpl
+        def he_method1(self, arg):
+            return arg * 10
+
+    plugin1, plugin2 = Plugin1(), Plugin2()
+    pm.register(plugin1)
+    pm.register(plugin2)
+
+    hc = pm.subset_hook_caller("he_method1", [plugin1])
+    assert hc(arg=2) == [20]
+
+
 def test_get_hookimpls(pm: PluginManager) -> None:
     class Hooks:
         @hookspec


### PR DESCRIPTION
## What changed

`PluginManager.subset_hook_caller()` now builds its exclusion set from the hook implementations registered on the target hook instead of checking whether each plugin has an attribute with the hook name.

## Why

A plugin can implement a hook through `@hookimpl(specname="...")`, so the plugin object does not need to expose an attribute with the hook name. In that case, `subset_hook_caller()` previously failed to exclude the plugin and the implementation still ran.

## Validation

- `PYTHONPATH=src python -m pytest testing\test_pluginmanager.py::test_subset_hook_caller_with_specname testing\test_pluginmanager.py::test_subset_hook_caller -q`
- `PYTHONPATH=src python -m pytest testing\test_pluginmanager.py -q`
- `PYTHONPATH=src python -m pytest -q`
- `uv run pytest -q`
- `uv run pre-commit run -a`