### PR TITLE
Fix surrogate values in hook tracing

### DIFF
--- a/changelog/681.bugfix.rst
+++ b/changelog/681.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed tracing crashes when hook arguments or return values contain surrogate
+characters.

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -503,7 +503,7 @@ class PluginManager:
             kwargs: Mapping[str, object],
         ) -> None:
             if outcome.exception is None:
-                hooktrace("finish", hook_name, "-->", outcome.get_result())
+                hooktrace("finish", hook_name, "-->", repr(outcome.get_result()))
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -35,7 +35,7 @@ class TagTracer:
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {value!r}\n")
 
         return "".join(lines)
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -695,6 +695,34 @@ def test_hook_tracing(he_pm: PluginManager) -> None:
         undo()
 
 
+def test_hook_tracing_safely_formats_surrogate_result() -> None:
+    class Hooks:
+        @hookspec(firstresult=True)
+        def result(self) -> str:
+            raise NotImplementedError()
+
+    class Plugin:
+        @hookimpl
+        def result(self) -> str:
+            return "\ud800"
+
+    pm = PluginManager("example")
+    pm.add_hookspecs(Hooks)
+    pm.register(Plugin())
+    out: list[bytes] = []
+    pm.trace.root.setwriter(lambda message: out.append(message.encode("utf-8")))
+    undo = pm.enable_tracing()
+    try:
+        assert pm.hook.result() == "\ud800"
+    finally:
+        undo()
+
+    assert out == [
+        b"  result [hook]\n",
+        b"  finish result --> '\\ud800' [hook]\n",
+    ]
+
+
 @pytest.mark.parametrize("historic", [False, True])
 def test_register_while_calling(
     pm: PluginManager,

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -57,6 +57,15 @@ def test_readable_output_dictargs(rootlogger: TagTracer) -> None:
     assert out2 == "test [test]\n    a: 1\n"
 
 
+def test_surrogate_dict_value_is_safely_formatted(rootlogger: TagTracer) -> None:
+    out: list[bytes] = []
+    rootlogger.setwriter(lambda message: out.append(message.encode("utf-8")))
+
+    rootlogger.get("test")("call", {"value": "\ud800"})
+
+    assert out == [b"call [test]\n    value: '\\ud800'\n"]
+
+
 def test_setprocessor(rootlogger: TagTracer) -> None:
     log = rootlogger.get("1")
     log2 = log.get("2")


### PR DESCRIPTION
## Summary

- render traced hook argument values with `repr` while preserving structural labels
- pre-format traced hook results with `repr` at the `PluginManager` boundary
- cover surrogate-containing kwargs and first-result hook returns
- add a bug-fix changelog fragment

Closes #681.

## Root cause and impact

Tracing formatted arbitrary Python values with `str`, which could leave literal
surrogate characters in the resulting message. Writers using ordinary UTF-8
encoding then raised `UnicodeEncodeError`. Applying `repr` only at the two value
positions safely escapes surrogates without quoting trace labels or double-
representing unrelated structural content.

## Validation

- `uv run pytest testing/test_tracer.py testing/test_pluginmanager.py::test_hook_tracing testing/test_pluginmanager.py::test_hook_tracing_safely_formats_surrogate_result` — 8 passed
- `uv run pytest` — 141 passed
- `uv run pre-commit run -a` — all hooks passed, including Ruff, Flake8, MyPy, formatting, and ReST checks
- `git diff --check`

I used Codex as an implementation assistant, reviewed and validated the complete
change, and take responsibility for the contribution and follow-up.
