### PR TITLE
docs: fix nitpicky build for TYPE_CHECKING-only annotations

### DIFF
--- a/changelog/417.trivial.rst
+++ b/changelog/417.trivial.rst
@@ -1,0 +1,1 @@
+Fix the ``tox -e docs`` build, which failed under ``sphinx-build -W`` because nitpicky mode reported unresolved references to the private names ``_tracing.TagTracerSub``, ``DistFacade`` and ``_Plugin``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,11 +63,19 @@ man_pages = [(master_doc, "pluggy", "pluggy Documentation", [author], 1)]
 autodoc_member_order = "bysource"
 
 nitpicky = True
+# Some annotations in `pluggy._manager` reference names that only exist under
+# `typing.TYPE_CHECKING` (`DistFacade`, `importlib.metadata`), so autodoc cannot
+# evaluate them and falls back to the annotation as written in the source.
+# That means private names show up both fully qualified and as written.
 nitpick_ignore = {
     # Don't want to expose this yet (see #428).
     ("py:class", "pluggy._tracing.TagTracerSub"),
+    ("py:class", "_tracing.TagTracerSub"),
     # Compat hack, don't want to expose it.
     ("py:class", "pluggy._compat.DistFacade"),
+    ("py:class", "DistFacade"),
+    # Private alias for `object`.
+    ("py:class", "_Plugin"),
     # `types.ModuleType` turns into `module` but then fails to resolve...
     ("py:class", "module"),
     # Just a TypeVar.


### PR DESCRIPTION
## Summary

`tox -e docs` currently fails on `main` because Sphinx runs in nitpicky mode with warnings treated as errors and cannot resolve four private annotation targets from `pluggy._manager`.

The annotations now fall back to their source spellings when `typing.get_type_hints()` encounters names imported only under `TYPE_CHECKING`. The existing `nitpick_ignore` entries cover the qualified spellings, but not the emitted `_tracing.TagTracerSub`, `DistFacade`, and `_Plugin` targets.

This adds those three precise targets to `nitpick_ignore`. It does not broaden the ignore pattern or change runtime code.

Refs pytest-dev/pluggy#417.

## Test plan

- `uv run pytest` — 141 passed
- `uv run pre-commit run -a` — all 11 hooks passed
- `uv run --with tox tox -e docs` — build succeeded (failed before this change)

## AI assistance

I used Claude Code with Claude Opus 5 to investigate the regression, prepare the patch, and run an adversarial review. The commit includes the corresponding co-author and session attribution.
