### PR TITLE
fix: safe formatting for surrogates in pluggy tracing

### DIFF
--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -29,13 +29,17 @@ class TagTracer:
         else:
             extra = {}
 
-        content = " ".join(map(str, args))
+        def _safe(obj: object) -> str:
+            text = str(obj)
+            return text.encode("utf-8", "backslashreplace").decode("utf-8")
+
+        content = " ".join(map(_safe, args))
         indent = "  " * self.indent
 
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {_safe(value)}\n")
 
         return "".join(lines)
 


### PR DESCRIPTION
## Summary
Tracing crashed with `UnicodeEncodeError` when hook args contained surrogate escapes.

## Change
Format trace values with `backslashreplace` so surrogates are escaped safely.

Fixes #681
