### PR TITLE
test: cover pluggy.__version__ getattr and HookCaller._remove_plugin …

### DIFF
--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -230,6 +230,15 @@ def test_dist_facade_identity_equality_and_hash() -> None:
     assert {fc1: "ok"}[fc1] == "ok"
 
 
+def test_dunder_version() -> None:
+    assert pluggy.__version__ == distribution("pluggy").version
+
+
+def test_dunder_getattr_missing_raises() -> None:
+    with pytest.raises(AttributeError, match="module pluggy has no attribute 'nope'"):
+        pluggy.nope
+
+
 def test_hookimpl_disallow_invalid_combination() -> None:
     decorator = hookspec(historic=True, firstresult=True)
     with pytest.raises(ValueError, match="cannot have a historic firstresult hook"):

--- a/testing/test_hookcaller.py
+++ b/testing/test_hookcaller.py
@@ -511,3 +511,25 @@ def test_call_extra_hook_order(hc: HookCaller, addmeth: AddMeth) -> None:
         "2",
         "3",
     ]
+
+
+def test_remove_plugin_not_found_raises(hc: HookCaller, pm: PluginManager) -> None:
+    """_remove_plugin() raises ValueError for a plugin that never registered
+    an implementation on this particular hook caller."""
+
+    class Plugin:
+        @hookimpl
+        def he_method1(self, arg):
+            pass  # pragma: no cover
+
+    plugin = Plugin()
+    pm.register(plugin)
+    assert len(hc.get_hookimpls()) == 1
+
+    other = Plugin()
+    with pytest.raises(ValueError, match=f"plugin {other!r} not found"):
+        hc._remove_plugin(other)
+
+    # the failed removal must not have touched the existing registration
+    assert len(hc.get_hookimpls()) == 1
+    pm.unregister(plugin)


### PR DESCRIPTION
…not-found path

Ran the suite under coverage.py and found two real gaps in otherwise near-100% covered code. The module-level __getattr__ that lazily resolves pluggy.__version__ via importlib.metadata (added per changelog/590.trivial.rst) had no test exercising either branch. And HookCaller._remove_plugin's ValueError, raised when asked to remove a plugin that never registered on that hook, was untested even though the normal removal path is well covered through
PluginManager.unregister.