### PR TITLE
lint: fix B018 failure on main

### DIFF
--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -236,7 +236,7 @@ def test_dunder_version() -> None:
 
 def test_dunder_getattr_missing_raises() -> None:
     with pytest.raises(AttributeError, match="module pluggy has no attribute 'nope'"):
-        pluggy.nope
+        _ = pluggy.nope
 
 
 def test_hookimpl_disallow_invalid_combination() -> None:


### PR DESCRIPTION
`pre-commit.ci - push` is failing on `main` (de34583) with:

```
B018 Found useless expression. Either assign it to a variable or remove it.
   --> testing/test_details.py:239:9
239 |         pluggy.nope
```

Two changes landed close together and combined into this:

* 11ce4b9 (pre-commit autoupdate) bumped ruff `v0.15.22` → `v0.16.2`, and ruff 0.16 enables flake8-bugbear in the default rule set. Bisected: 0.15.0 clean, 0.16.0 flags it. `[tool.ruff.lint] extend-select` does not list `B`, so this comes purely from the new defaults.
* #718 added `test_dunder_getattr_missing_raises` with a bare `pluggy.nope` expression. That PR already fixed four other B018 sites in 237edb6, this one was missed.

The `test` workflow stays green because linting runs on pre-commit.ci, which is why the red status was easy to miss on merge.

Fix binds the expression to `_`, matching what 237edb6 did for `_ = module.x.broken`.

`uv run pre-commit run -a` and `uv run pytest` (144 passed) are green with this applied.

No changelog fragment — test-only lint fix, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)