### PR TITLE
Point the missing-argument warning at the code making the hook call

### DIFF
--- a/changelog/727.bugfix.rst
+++ b/changelog/727.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the warning for hookspec arguments missing from a hook call being attributed to pluggy's own frame instead of to the code making the call. This affected ``HookCaller.__call__``, ``call_historic`` and ``call_extra``.

--- a/src/pluggy/_hooks.py
+++ b/src/pluggy/_hooks.py
@@ -520,7 +520,10 @@ class HookCaller:
                     warnings.warn(
                         f"Argument(s) {notincall} which are declared in the hookspec "
                         "cannot be found in this hook call",
-                        stacklevel=2,
+                        # 3, not 2: the warning is raised in this helper, which
+                        # is called by __call__/call_historic/call_extra, which
+                        # are called by the code making the hook call.
+                        stacklevel=3,
                     )
                     break
 

--- a/testing/test_details.py
+++ b/testing/test_details.py
@@ -180,6 +180,37 @@ def test_not_all_arguments_are_provided_issues_a_warning(pm: PluginManager) -> N
         pm.hook.herstory.call_historic(kwargs={})
 
 
+def test_not_all_arguments_warning_points_at_the_caller(pm: PluginManager) -> None:
+    """The warning must be attributed to the code making the hook call.
+
+    It is raised inside a helper two frames below the caller, so a stacklevel
+    that is off by one blames pluggy's own frame instead.
+    """
+
+    class Spec:
+        @hookspec
+        def hello(self, arg1, arg2):
+            pass  # pragma: no cover
+
+        @hookspec(historic=True)
+        def herstory(self, arg1, arg2):
+            pass  # pragma: no cover
+
+    pm.add_hookspecs(Spec)
+
+    with pytest.warns(UserWarning) as record:
+        pm.hook.hello(arg1=1)
+    assert record[0].filename == __file__
+
+    with pytest.warns(UserWarning) as record:
+        pm.hook.hello.call_extra([], kwargs={})
+    assert record[0].filename == __file__
+
+    with pytest.warns(UserWarning) as record:
+        pm.hook.herstory.call_historic(kwargs={})
+    assert record[0].filename == __file__
+
+
 def test_repr() -> None:
     class Plugin:
         @hookimpl


### PR DESCRIPTION
The warning for hookspec arguments missing from a hook call is attributed to pluggy's own frame instead of to the code that made the call:

```python
pm.hook.hello(arg1=1)     # user_code.py:22, arg2 missing from the spec
```

```
attributed to : _hooks.py:539     <- HookCaller.__call__
expected      : user_code.py:22
```

`e77787b` ("hooks: also verify kwargs are per spec in call_historic") moved the `warnings.warn` out of `HookCaller.__call__` and into the new `_verify_all_args_are_provided` so `call_historic` could share it, and carried `stacklevel=2` over unchanged. Inside `__call__` that level was the caller; inside the helper it is `__call__` itself. All three entry points call the helper directly, so all three are off by the same one:

| call path | before | after |
|---|---|---|
| `__call__` | `_hooks.py:539` | caller |
| `call_historic` | `_hooks.py:559` | caller |
| `call_extra` | `_hooks.py:580` | caller |

`stacklevel=3` restores the pre-`e77787b` behaviour for `__call__` and extends it to the two paths that never had it.

`test_not_all_arguments_are_provided_issues_a_warning` already covers all three paths, but only matches the message, so the attribution regressed silently. The new test asserts `record[0].filename == __file__` for each path; with `stacklevel=2` restored it fails and nothing else does.

`pytest testing/`: **145 passed** (144 passed / 1 failed on the reverted source). `pre-commit run --files src/pluggy/_hooks.py testing/test_details.py`: ruff check, ruff format, autoflake, pyupgrade, blacken-docs and mypy all pass.

Happy to add a `changelog/<PR>.bugfix.rst` fragment once this has a number, or to drop the test if you would rather keep the assertion to the message only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M5uTyCU4WcNTsPvGrErDo
