### PR TITLE
Make hook tracing unable to fail a hook call

### DIFF
--- a/changelog/424.bugfix.rst
+++ b/changelog/424.bugfix.rst
@@ -1,0 +1,5 @@
+Tracing no longer breaks hook execution when a traced object has a broken ``__repr__``
+or ``__str__``. Such a value is now rendered as
+``<[RuntimeError(...) raised in repr()] Broken object at 0x...>``, in the same style
+pytest uses for unpresentable objects, instead of propagating the exception out of the
+hook call.

--- a/changelog/681.bugfix.rst
+++ b/changelog/681.bugfix.rst
@@ -1,10 +1,3 @@
 Tracing no longer crashes with ``UnicodeEncodeError`` when a hook argument or return
 value contains lone surrogates; they are escaped with ``backslashreplace`` before the
-message reaches the writer.
-
-As part of this, traced *values* -- the hook keyword arguments and the hook return
-value -- are now formatted with ``repr()`` rather than ``str()``, so the trace output
-shows ``plugin_name: 'lfplugin'`` and ``start_path: PosixPath('/x')`` instead of
-``plugin_name: lfplugin`` and ``start_path: /x``. Structural labels such as the hook
-name and ``finish``/``-->`` markers are unchanged. Consumers that parse
-``--debug``-style trace output may need to adapt.
+message reaches the writer. Trace output is otherwise unchanged.

--- a/changelog/681.bugfix.rst
+++ b/changelog/681.bugfix.rst
@@ -1,0 +1,10 @@
+Tracing no longer crashes with ``UnicodeEncodeError`` when a hook argument or return
+value contains lone surrogates; they are escaped with ``backslashreplace`` before the
+message reaches the writer.
+
+As part of this, traced *values* -- the hook keyword arguments and the hook return
+value -- are now formatted with ``repr()`` rather than ``str()``, so the trace output
+shows ``plugin_name: 'lfplugin'`` and ``start_path: PosixPath('/x')`` instead of
+``plugin_name: lfplugin`` and ``start_path: /x``. Structural labels such as the hook
+name and ``finish``/``-->`` markers are unchanged. Consumers that parse
+``--debug``-style trace output may need to adapt.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1001,13 +1001,13 @@ Each hook call is traced with its keyword arguments, followed by a ``finish``
 line carrying the result::
 
     he_method1 [hook]
-        arg: 'value'
-        path: PosixPath('/tmp')
+        arg: value
+        path: /tmp
     finish he_method1 --> ['value'] [hook]
 
-Traced values are rendered with :func:`repr`, so their type stays visible, and
-the rendering is defensive: an object whose ``__repr__`` raises is shown as
-``<[RuntimeError(...) raised in repr()] Broken object at 0x...>``, and lone
+Values are rendered with :func:`str`, and the rendering is defensive: an object
+whose ``__str__`` raises is shown as
+``<[RuntimeError(...) raised in str()] Broken object at 0x...>``, and lone
 surrogates are backslash-escaped, so enabling tracing can never turn a working
 hook call into a failing one.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -997,6 +997,20 @@ undo function to disable the behaviour.
     pm.trace.root.setwriter(print)
     undo = pm.enable_tracing()
 
+Each hook call is traced with its keyword arguments, followed by a ``finish``
+line carrying the result::
+
+    he_method1 [hook]
+        arg: 'value'
+        path: PosixPath('/tmp')
+    finish he_method1 --> ['value'] [hook]
+
+Traced values are rendered with :func:`repr`, so their type stays visible, and
+the rendering is defensive: an object whose ``__repr__`` raises is shown as
+``<[RuntimeError(...) raised in repr()] Broken object at 0x...>``, and lone
+surrogates are backslash-escaped, so enabling tracing can never turn a working
+hook call into a failing one.
+
 
 Call monitoring
 ---------------

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -595,7 +595,12 @@ class PluginManager:
             kwargs: Mapping[str, object],
         ) -> None:
             if outcome.exception is None:
-                hooktrace("finish", hook_name, "-->", outcome.get_result())
+                hooktrace(
+                    "finish",
+                    hook_name,
+                    "-->",
+                    _tracing._safe_repr(outcome.get_result()),
+                )
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)

--- a/src/pluggy/_manager.py
+++ b/src/pluggy/_manager.py
@@ -595,12 +595,7 @@ class PluginManager:
             kwargs: Mapping[str, object],
         ) -> None:
             if outcome.exception is None:
-                hooktrace(
-                    "finish",
-                    hook_name,
-                    "-->",
-                    _tracing._safe_repr(outcome.get_result()),
-                )
+                hooktrace("finish", hook_name, "-->", outcome.get_result())
             hooktrace.root.indent -= 1
 
         return self.add_hookcall_monitoring(before, after)

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -13,6 +13,60 @@ _Writer = Callable[[str], object]
 _Processor = Callable[[tuple[str, ...], tuple[Any, ...]], object]
 
 
+def _try_repr_or_str(obj: object) -> str:
+    try:
+        return repr(obj)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        return f'{type(obj).__name__}("{obj}")'
+
+
+def _format_repr_exception(exc: BaseException, obj: object, func: str) -> str:
+    try:
+        exc_info = _try_repr_or_str(exc)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException as inner:
+        exc_info = f"unpresentable exception ({_try_repr_or_str(inner)})"
+    name = type(obj).__name__
+    return f"<[{exc_info} raised in {func}()] {name} object at 0x{id(obj):x}>"
+
+
+def _escape_surrogates(text: str) -> str:
+    """Escape lone surrogates so the result survives any text writer.
+
+    ``repr()`` passes surrogates through unchanged when they originate in an
+    object's own ``__repr__``, and writing such a string to a utf-8 target
+    raises :exc:`UnicodeEncodeError` inside the trace call.
+    """
+    if text.isascii():
+        return text
+    return text.encode("utf-8", "backslashreplace").decode("utf-8")
+
+
+def _safe_str(obj: object) -> str:
+    """``str(obj)`` for structural trace labels, guaranteed not to raise."""
+    try:
+        text = str(obj)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException as exc:
+        text = _format_repr_exception(exc, obj, "str")
+    return _escape_surrogates(text)
+
+
+def _safe_repr(obj: object) -> str:
+    """``repr(obj)`` for traced values, guaranteed not to raise."""
+    try:
+        text = repr(obj)
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException as exc:
+        text = _format_repr_exception(exc, obj, "repr")
+    return _escape_surrogates(text)
+
+
 class TagTracer:
     def __init__(self) -> None:
         self._tags2proc: dict[tuple[str, ...], _Processor] = {}
@@ -29,13 +83,13 @@ class TagTracer:
         else:
             extra = {}
 
-        content = " ".join(map(str, args))
+        content = " ".join(map(_safe_str, args))
         indent = "  " * self.indent
 
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {value}\n")
+            lines.append(f"{indent}    {name}: {_safe_repr(value)}\n")
 
         return "".join(lines)
 

--- a/src/pluggy/_tracing.py
+++ b/src/pluggy/_tracing.py
@@ -22,7 +22,7 @@ def _try_repr_or_str(obj: object) -> str:
         return f'{type(obj).__name__}("{obj}")'
 
 
-def _format_repr_exception(exc: BaseException, obj: object, func: str) -> str:
+def _format_str_exception(exc: BaseException, obj: object) -> str:
     try:
         exc_info = _try_repr_or_str(exc)
     except (KeyboardInterrupt, SystemExit):
@@ -30,15 +30,15 @@ def _format_repr_exception(exc: BaseException, obj: object, func: str) -> str:
     except BaseException as inner:
         exc_info = f"unpresentable exception ({_try_repr_or_str(inner)})"
     name = type(obj).__name__
-    return f"<[{exc_info} raised in {func}()] {name} object at 0x{id(obj):x}>"
+    return f"<[{exc_info} raised in str()] {name} object at 0x{id(obj):x}>"
 
 
 def _escape_surrogates(text: str) -> str:
     """Escape lone surrogates so the result survives any text writer.
 
-    ``repr()`` passes surrogates through unchanged when they originate in an
-    object's own ``__repr__``, and writing such a string to a utf-8 target
-    raises :exc:`UnicodeEncodeError` inside the trace call.
+    A lone surrogate reaching the writer raises :exc:`UnicodeEncodeError`
+    inside the trace call for any utf-8 target, such as the file behind
+    pytest's ``--debug``.
     """
     if text.isascii():
         return text
@@ -46,24 +46,18 @@ def _escape_surrogates(text: str) -> str:
 
 
 def _safe_str(obj: object) -> str:
-    """``str(obj)`` for structural trace labels, guaranteed not to raise."""
+    """``str(obj)`` for tracing, guaranteed not to raise and always writable.
+
+    Tracing is a debugging aid, so it must never be the reason a hook call
+    fails, and the rendering stays ``str``-based to keep the trace output
+    readable.
+    """
     try:
         text = str(obj)
     except (KeyboardInterrupt, SystemExit):
         raise
     except BaseException as exc:
-        text = _format_repr_exception(exc, obj, "str")
-    return _escape_surrogates(text)
-
-
-def _safe_repr(obj: object) -> str:
-    """``repr(obj)`` for traced values, guaranteed not to raise."""
-    try:
-        text = repr(obj)
-    except (KeyboardInterrupt, SystemExit):
-        raise
-    except BaseException as exc:
-        text = _format_repr_exception(exc, obj, "repr")
+        text = _format_str_exception(exc, obj)
     return _escape_surrogates(text)
 
 
@@ -89,7 +83,7 @@ class TagTracer:
         lines = [f"{indent}{content} [{':'.join(tags)}]\n"]
 
         for name, value in extra.items():
-            lines.append(f"{indent}    {name}: {_safe_repr(value)}\n")
+            lines.append(f"{indent}    {name}: {_safe_str(value)}\n")
 
         return "".join(lines)
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -945,8 +945,8 @@ def test_hook_tracing_escapes_surrogate_values(pm: PluginManager) -> None:
 
     assert result == "\ud800"
     assert out == [
-        "  he_method1 [hook]\n      arg: '\\ud800'\n",
-        "  finish he_method1 --> '\\ud800' [hook]\n",
+        "  he_method1 [hook]\n      arg: \\ud800\n",
+        "  finish he_method1 --> \\ud800 [hook]\n",
     ]
 
 
@@ -978,7 +978,7 @@ def test_hook_tracing_with_broken_repr(he_pm: PluginManager) -> None:
     assert result == [arg]
     assert len(out) == 2
     assert "he_method1" in out[0]
-    assert "RuntimeError('repr is broken') raised in repr()" in out[0]
+    assert "RuntimeError('repr is broken') raised in str()" in out[0]
     assert "BrokenRepr object at 0x" in out[0]
     assert "finish" in out[1]
 

--- a/testing/test_pluginmanager.py
+++ b/testing/test_pluginmanager.py
@@ -912,6 +912,77 @@ def test_hook_tracing(he_pm: PluginManager) -> None:
         undo()
 
 
+def test_hook_tracing_escapes_surrogate_values(pm: PluginManager) -> None:
+    """Surrogates in traced arguments and results never reach the writer.
+
+    Regression test for #681 (pytest-dev/pytest#13750).
+    """
+
+    class Hooks:
+        @hookspec(firstresult=True)
+        def he_method1(self, arg: object) -> object:
+            raise NotImplementedError()
+
+    class Plugin:
+        @hookimpl
+        def he_method1(self, arg: object) -> object:
+            return arg
+
+    out: list[str] = []
+
+    def write(message: str) -> None:
+        message.encode()
+        out.append(message)
+
+    pm.add_hookspecs(Hooks)
+    pm.register(Plugin())
+    pm.trace.root.setwriter(write)
+    undo = pm.enable_tracing()
+    try:
+        result = pm.hook.he_method1(arg="\ud800")
+    finally:
+        undo()
+
+    assert result == "\ud800"
+    assert out == [
+        "  he_method1 [hook]\n      arg: '\\ud800'\n",
+        "  finish he_method1 --> '\\ud800' [hook]\n",
+    ]
+
+
+def test_hook_tracing_with_broken_repr(he_pm: PluginManager) -> None:
+    """A broken ``__repr__`` does not break the hook call.
+
+    Regression test for #424 (kedro-org/kedro#2630).
+    """
+
+    class BrokenRepr:
+        def __repr__(self) -> str:
+            raise RuntimeError("repr is broken")
+
+    class api1:
+        @hookimpl
+        def he_method1(self, arg):
+            return arg
+
+    he_pm.register(api1())
+    out: list[str] = []
+    he_pm.trace.root.setwriter(out.append)
+    undo = he_pm.enable_tracing()
+    arg = BrokenRepr()
+    try:
+        result = he_pm.hook.he_method1(arg=arg)
+    finally:
+        undo()
+
+    assert result == [arg]
+    assert len(out) == 2
+    assert "he_method1" in out[0]
+    assert "RuntimeError('repr is broken') raised in repr()" in out[0]
+    assert "BrokenRepr object at 0x" in out[0]
+    assert "finish" in out[1]
+
+
 @pytest.mark.parametrize("historic", [False, True])
 def test_register_while_calling(
     pm: PluginManager,

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -220,3 +220,69 @@ def test_broken_str_label_does_not_raise(rootlogger: TagTracer) -> None:
     assert "RuntimeError('str is broken') raised in str()" in out
     assert "BrokenStr object at 0x" in out
     out.encode()
+
+
+def test_keyboard_interrupt_from_str_propagates(rootlogger: TagTracer) -> None:
+    """Ctrl-C during a traced call still interrupts, it is not swallowed."""
+
+    class Interrupting:
+        def __str__(self) -> str:
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        rootlogger._format_message(["test"], ["test", {"arg": Interrupting()}])
+
+
+def test_broken_exception_repr_is_handled(rootlogger: TagTracer) -> None:
+    """The exception explaining the failure may itself be unpresentable."""
+
+    class BadError(Exception):
+        def __repr__(self) -> str:
+            raise RuntimeError("exception repr is broken")
+
+        def __str__(self) -> str:
+            return "readable message"
+
+    class Broken:
+        def __str__(self) -> str:
+            raise BadError
+
+    out = rootlogger._format_message(["test"], ["test", {"arg": Broken()}])
+    assert 'BadError("readable message") raised in str()' in out
+    assert "Broken object at 0x" in out
+
+
+def test_unpresentable_exception_is_handled(rootlogger: TagTracer) -> None:
+    """Neither repr nor str of the exception works, and tracing still survives."""
+
+    class UnpresentableError(Exception):
+        def __repr__(self) -> str:
+            raise RuntimeError("exception repr is broken")
+
+        def __str__(self) -> str:
+            raise RuntimeError("exception str is broken")
+
+    class Broken:
+        def __str__(self) -> str:
+            raise UnpresentableError
+
+    out = rootlogger._format_message(["test"], ["test", {"arg": Broken()}])
+    assert "unpresentable exception (RuntimeError('exception str is broken'))" in out
+    assert "Broken object at 0x" in out
+
+
+def test_keyboard_interrupt_from_exception_repr_propagates(
+    rootlogger: TagTracer,
+) -> None:
+    """Ctrl-C while rendering the failure explanation propagates as well."""
+
+    class InterruptingError(Exception):
+        def __repr__(self) -> str:
+            raise KeyboardInterrupt
+
+    class Broken:
+        def __str__(self) -> str:
+            raise InterruptingError
+
+    with pytest.raises(KeyboardInterrupt):
+        rootlogger._format_message(["test"], ["test", {"arg": Broken()}])

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -158,3 +158,71 @@ def test_dbl_plugin_tracing(pm: PluginManager) -> None:
         "  hello [hook]\n      arg: 3\n",
         "  finish hello --> [] [hook]\n",
     ]
+class BrokenRepr:
+    def __repr__(self) -> str:
+        raise RuntimeError("repr is broken")
+
+
+class BrokenStr:
+    def __repr__(self) -> str:
+        return "BrokenStr()"
+
+    def __str__(self) -> str:
+        raise RuntimeError("str is broken")
+
+
+class SurrogateRepr:
+    def __repr__(self) -> str:
+        return "\ud800"
+
+
+def test_dictargs_use_repr(rootlogger: TagTracer) -> None:
+    """Traced values are repred so their type is visible in the log."""
+    out = rootlogger._format_message(["test"], ["call", {"name": "value", "n": 1}])
+    assert out == "call [test]\n    name: 'value'\n    n: 1\n"
+
+
+def test_labels_are_not_repred(rootlogger: TagTracer) -> None:
+    """Structural labels stay unquoted, only values are repred."""
+    out = rootlogger._format_message(["test"], ["finish", "he_method1", "-->", "[]"])
+    assert out == "finish he_method1 --> [] [test]\n"
+
+
+def test_dictargs_escape_surrogate_values(rootlogger: TagTracer) -> None:
+    out = rootlogger._format_message(["test"], ["test", {"arg": "\ud800"}])
+    assert out == "test [test]\n    arg: '\\ud800'\n"
+    out.encode()
+
+
+def test_escape_surrogates_from_repr(rootlogger: TagTracer) -> None:
+    """A surrogate coming out of the object's own repr is escaped too."""
+    out = rootlogger._format_message(["test"], ["test", {"arg": SurrogateRepr()}])
+    assert out == "test [test]\n    arg: \\ud800\n"
+    out.encode()
+
+
+def test_escape_surrogates_in_labels(rootlogger: TagTracer) -> None:
+    out = rootlogger._format_message(["test"], ["\ud800"])
+    assert out == "\\ud800 [test]\n"
+    out.encode()
+
+
+def test_non_ascii_values_are_kept(rootlogger: TagTracer) -> None:
+    """Legible text is not mangled, only lone surrogates are escaped."""
+    out = rootlogger._format_message(["test"], ["héllo", {"arg": "wörld"}])
+    assert out == "héllo [test]\n    arg: 'wörld'\n"
+    out.encode()
+
+
+def test_broken_repr_value_does_not_raise(rootlogger: TagTracer) -> None:
+    out = rootlogger._format_message(["test"], ["test", {"arg": BrokenRepr()}])
+    assert "RuntimeError('repr is broken') raised in repr()" in out
+    assert "BrokenRepr object at 0x" in out
+    out.encode()
+
+
+def test_broken_str_label_does_not_raise(rootlogger: TagTracer) -> None:
+    out = rootlogger._format_message(["test"], [BrokenStr()])
+    assert "RuntimeError('str is broken') raised in str()" in out
+    assert "BrokenStr object at 0x" in out
+    out.encode()

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -176,21 +176,15 @@ class SurrogateRepr:
         return "\ud800"
 
 
-def test_dictargs_use_repr(rootlogger: TagTracer) -> None:
-    """Traced values are repred so their type is visible in the log."""
+def test_dictargs_keep_str_rendering(rootlogger: TagTracer) -> None:
+    """Values keep their ``str`` rendering, the trace is a log not a repr dump."""
     out = rootlogger._format_message(["test"], ["call", {"name": "value", "n": 1}])
-    assert out == "call [test]\n    name: 'value'\n    n: 1\n"
-
-
-def test_labels_are_not_repred(rootlogger: TagTracer) -> None:
-    """Structural labels stay unquoted, only values are repred."""
-    out = rootlogger._format_message(["test"], ["finish", "he_method1", "-->", "[]"])
-    assert out == "finish he_method1 --> [] [test]\n"
+    assert out == "call [test]\n    name: value\n    n: 1\n"
 
 
 def test_dictargs_escape_surrogate_values(rootlogger: TagTracer) -> None:
     out = rootlogger._format_message(["test"], ["test", {"arg": "\ud800"}])
-    assert out == "test [test]\n    arg: '\\ud800'\n"
+    assert out == "test [test]\n    arg: \\ud800\n"
     out.encode()
 
 
@@ -210,13 +204,13 @@ def test_escape_surrogates_in_labels(rootlogger: TagTracer) -> None:
 def test_non_ascii_values_are_kept(rootlogger: TagTracer) -> None:
     """Legible text is not mangled, only lone surrogates are escaped."""
     out = rootlogger._format_message(["test"], ["héllo", {"arg": "wörld"}])
-    assert out == "héllo [test]\n    arg: 'wörld'\n"
+    assert out == "héllo [test]\n    arg: wörld\n"
     out.encode()
 
 
 def test_broken_repr_value_does_not_raise(rootlogger: TagTracer) -> None:
     out = rootlogger._format_message(["test"], ["test", {"arg": BrokenRepr()}])
-    assert "RuntimeError('repr is broken') raised in repr()" in out
+    assert "RuntimeError('repr is broken') raised in str()" in out
     assert "BrokenRepr object at 0x" in out
     out.encode()
 

--- a/testing/test_tracer.py
+++ b/testing/test_tracer.py
@@ -158,15 +158,14 @@ def test_dbl_plugin_tracing(pm: PluginManager) -> None:
         "  hello [hook]\n      arg: 3\n",
         "  finish hello --> [] [hook]\n",
     ]
+
+
 class BrokenRepr:
     def __repr__(self) -> str:
         raise RuntimeError("repr is broken")
 
 
 class BrokenStr:
-    def __repr__(self) -> str:
-        return "BrokenStr()"
-
     def __str__(self) -> str:
         raise RuntimeError("str is broken")
 


### PR DESCRIPTION
> **AI-authored.** I asked Claude Code (Opus 5) to work through the tracing PR
> cluster and produce a single change superseding it. The code, the tests, the
> measurements and the text below are the agent's work. I read it and I am
> posting it, and I will follow up on review comments myself.

Closes #424. Closes #681. Supersedes #627, #666, #684, #716.

## The two bugs

Tracing can turn a working hook call into a failing one:

- **#424** — an object whose `__repr__`/`__str__` raises propagates that exception
  out of the hook call (originally [kedro-org/kedro#2630](https://github.com/kedro-org/kedro/issues/2630)).
- **#681** — a lone surrogate in a hook argument or return value produces a message
  the writer cannot encode (originally [pytest-dev/pytest#13750](https://github.com/pytest-dev/pytest/issues/13750)).

Against `main`, with a writer that encodes to utf-8 the way pytest's `--debug` file does:

```
surrogate    UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 25
broken repr  RuntimeError: repr is broken
```

With this branch, both print `OK`.

## The change

One helper in `_tracing.py`, in the shape of pytest's `saferepr` (as #424 asked for),
applied to both the positional labels and the keyword values:

- `_safe_str()` — `KeyboardInterrupt` and `SystemExit` still propagate, anything else
  renders as `<[RuntimeError('str is broken') raised in str()] BrokenStr object at 0x...>`.
  `BaseException` rather than `Exception`, because pytest's `OutcomeException` — and so
  `pytest.fail()`/`skip()` — sits outside the `Exception` hierarchy, and a `__repr__`
  that fails a test while `--debug` is on is exactly the reported scenario.
- `_escape_surrogates()` afterwards — `backslashreplace`, which also covers surrogates
  that come out of an object's own `__repr__`, a case `repr()` alone does not fix. It
  short-circuits on ASCII text, which is nearly all of it.

**`pytest --debug` output is unchanged**: 674 trace lines on a sample run, byte for byte
identical to `main` once addresses are normalised. Nothing is added, nothing is quoted,
nothing is reformatted — the only difference is that the two inputs above no longer raise.

## Why the trace output is left alone, despite #681

#681 and #627 also called for rendering traced values with `repr()` so their type is
visible (`plugin_name: 'lfplugin'`, `start_path: PosixPath('/x')`). The first commit here
implements that; the second backs it out. Both are kept so the decision is reviewable.

**The reason is that the trace is pytest UX.** `--debug` output is read by a human
scanning for the hook that misbehaved, and a fix for a crash nobody hits in normal use
should not make that scan worse for everyone who does. I am not willing to take that
trade in pluggy — the fix has to be invisible to people who were not hitting the bug.

The worst case is a value meant to be read as a block. With `enable_assertion_pass_hook`,
pytest passes the assertion explanation to `pytest_assertion_pass` as a multi-line string.
Under `str()` the trace shows it as written:

```
    expl: {'x': [0, 1, ...} == {'x': [0, 1, ...}

      Omitting 2 identical items, use -vv to show
      Use -v to get more diff
```

Under `repr()` the same value becomes one escaped line:

```
    expl: "{'x': [0, 1, ...} == {'x': [0, 1, ...}\n  \n  Omitting 2 identical items, use -vv to show\n  Use -v to get more diff"
```

The measurement that settles it, taken on a real `pytest --debug` run — 439 traced kwarg
values, of which 123 render differently under `repr()`:

| what changes | count |
|---|---|
| a string gains quotes (`lfplugin` → `'lfplugin'`) | ~115 |
| a path gains its type (`/tmp/x` → `PosixPath('/tmp/x')` / `local('/tmp/x')`) | 13 |
| an enum gains its name (`1` → `<ExitCode.TESTS_FAILED: 1>`) | 2 |

94% of the delta is quote noise on strings that were already readable. The genuine wins
are real — `path` and `collection_path` printing the same text while being a
`py.path.local` and a `PosixPath` is exactly the confusion a trace should resolve — but
they are 15 lines out of 674, and they are not worth the other 115.

None of that blocks the bug fixes: **they never depended on `repr()`.** The guard and the
surrogate escaping live in `_safe_str`, so #424 and #681 close either way. Surrogates
render as `arg: \ud800` rather than `arg: '\ud800'`; both are legible, neither raises.

So the type-visibility idea is not rejected, only unbundled. If it is still wanted it can
be argued on its own merits in #681 — as a deliberate output change, with its own
changelog entry and its own discussion about what pytest's debug log should look like —
rather than riding along with a crash fix that has to ship regardless.

The one thing `repr()` would buy on such a value is keeping the log's one-line-per-value
structure intact for a machine reading it. That is a parsing concern, and it does not
outweigh making the block unreadable for the person the log is written for.

## Relation to the existing PRs

Each approach against the same matrix (all cells measured, not assumed):

| input | `main` | #666 | #684 | #716 | this PR |
|---|---|---|---|---|---|
| surrogate in a kwarg | crash | crash | fixed | fixed | fixed |
| surrogate in the hook result | crash | crash | fixed | fixed | fixed |
| object whose `__repr__` *returns* a surrogate | crash | crash | crash | fixed | fixed |
| object with a broken `__repr__` | crash | fixed | crash | crash | fixed |
| value passed positionally by a downstream `pm.trace()` caller | crash | fixed | not covered | fixed | fixed |
| `pytest --debug` output unchanged | — | yes | no (16% of lines, plus escaped blocks) | yes | yes |

- **#666**'s guard is carried over and widened — `BaseException` rather than `Exception`,
  and pytest's message format rather than a bespoke one. Its test is carried over. Thanks
  @ShipItAndPray.
- **#716**'s insight that positional args need sanitising too is carried over, and it is
  what keeps downstream `pm.trace()` callers (pytest calls it directly) safe — and what
  makes the `_manager.py` change in #684 unnecessary. Thanks @ltsyk.
- **#684** contributed the regression tests for both the kwarg and the result path, which
  are carried over; its `repr()` change is the part discussed above. Thanks @Himanshuagrawal4.
- **#627** is where all of this was worked out. Thanks @Ghanchu.

## Testing

- `uv run pytest` — 180 passed.
- `uv run pre-commit run -a` — all hooks pass.
- `_tracing.py` at 100% statement and branch coverage.
- 13 new tests: 7 fail on `main`, 2 pin the existing str rendering and the already-correct
  handling of legible non-ASCII, and 4 cover the guards themselves — an exception whose
  own repr fails, one whose repr and str both fail, and `KeyboardInterrupt` raised from
  the value and from the explanation.
- `pytest --debug` output diffed against `main`: 0 differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
